### PR TITLE
Improve CLI output with Claude-style stream rendering

### DIFF
--- a/docs/plans/cli-output-prettifier.md
+++ b/docs/plans/cli-output-prettifier.md
@@ -1,0 +1,126 @@
+# Improve `ralph-ghafk` / `ralph-afk` CLI output (Claude-Code-like)
+
+## Context
+
+Today the harness streams Claude Code CLI's `--output-format stream-json` events and re-prints them as flat `[bracket]` lines on stderr (model init, `[tool] Bash ...`, `[tool:ok] ...`, `[thinking]`, `[docker] ...`) plus raw assistant text on stdout. It is functional but hard to scan during long AFK runs: no visual grouping of a tool call with its result, no color, no distinction between iteration boundaries, and the `[docker]` passthrough noise mixes with substantive events.
+
+Goal: re-render the same stream-json events so a live run reads like Claude Code's own pretty terminal output — `●` bullets for assistant turns and tool calls, `⎿` continuation glyph for tool results, cyan tool names, dim metadata, clear iteration/stage banners — while staying safe when piped to a file or CI log.
+
+All the data needed is already in the stream (`runner.ts:37-42`); this is purely a rendering change in `renderEvent` plus a banner update in `loop.ts`. No protocol or stage changes.
+
+## Scope
+
+In: `packages/core/src/runner.ts` (`renderEvent`, helpers, `streamDocker` stderr handling), `packages/core/src/loop.ts` (iteration/stage banner).
+Out: `apps/cli/bin/*.js` (no changes), templates, stages, Dockerfile, ndjson log format (stays byte-identical — only terminal rendering changes).
+
+## Design
+
+### 1. TTY-gated styling (`runner.ts`, top-of-file helpers)
+
+Add a small module-local style layer. No new prod deps (matches existing "small files" style).
+
+```ts
+const USE_COLOR =
+  process.stdout.isTTY === true &&
+  process.env.NO_COLOR == null &&
+  process.env.TERM !== "dumb";
+
+const c = (code: string, s: string) =>
+  USE_COLOR ? `\x1b[${code}m${s}\x1b[0m` : s;
+const dim = (s: string) => c("2", s);
+const bold = (s: string) => c("1", s);
+const cyan = (s: string) => c("36", s);
+const green = (s: string) => c("32", s);
+const red = (s: string) => c("31", s);
+const yellow = (s: string) => c("33", s);
+const magenta = (s: string) => c("35", s);
+
+const SYM = USE_COLOR
+  ? { bullet: "●", cont: "⎿", arrow: "›" }
+  : { bullet: "*", cont: "  >", arrow: ">" };
+```
+
+Honors `NO_COLOR` (de-facto standard) and `TERM=dumb`. Plain ASCII fallback keeps log files / CI clean.
+
+### 2. Event rendering (`renderEvent` in `runner.ts:253`)
+
+Pair tool_use with tool_result by carrying a small `Map<tool_use_id, {name, startedAt}>` inside `streamDocker`'s closure (currently dropped — `AssistantBlock.id` and `UserBlock.tool_use_id` exist in the type but aren't used). Pass the map to `renderEvent` so result lines can show the originating tool name and elapsed ms.
+
+Per-event format (all to stderr except assistant text → stdout, unchanged):
+
+| Event                    | Today                    | New                                                                                     |
+| ------------------------ | ------------------------ | --------------------------------------------------------------------------------------- |
+| `system/init`            | `[init] model=… cwd=…`   | `dim("───") bold("init") dim(" model=… cwd=…")`                                         |
+| `assistant/text`         | raw text + `\r\n\n`      | `bold(cyan("●")) " "` + first line; subsequent lines indented 2 spaces. Keep on stdout. |
+| `assistant/thinking`     | `[thinking]`             | `dim("● thinking…")` (one-line marker, per user choice)                                 |
+| `assistant/tool_use`     | `[tool] Bash command=…`  | `cyan("●") " " bold(name) " " dim(previewInput(...))`                                   |
+| `user/tool_result` ok    | `[tool:ok] …`            | `dim(SYM.cont) " " green("✓") " " bold(toolName) dim(" ("+ms+"ms) ") dim(snippet)`      |
+| `user/tool_result` error | `[tool:error] …`         | `dim(SYM.cont) " " red("✗") " " bold(toolName) red(" failed") "\n  " red(snippet)`      |
+| `result` is_error        | `[result] is_error=true` | `red("● result errored")`                                                               |
+
+Tool-name lookup: when rendering a `user.tool_result`, read `block.tool_use_id` and resolve from the map. Fallback: `"tool"` if missing.
+
+Snippet rules unchanged (`stringifyToolResult`, `truncate`, 120-char preview for ok / 400 for error — drop today's 400/800 because Claude Code's own output is terser).
+
+### 3. Iteration / stage banner (`loop.ts:29`)
+
+Replace:
+
+```
+[sandcastle] iteration 1/3 stage 1/2 (ghafk-implementer)
+```
+
+With (when colored):
+
+```
+━━━ iteration 1/3 · ghafk-implementer (stage 1/2) ━━━
+```
+
+Plain fallback:
+
+```
+== iteration 1/3 · ghafk-implementer (stage 1/2) ==
+```
+
+Color: dim rule, bold stage name. Same line lives in `loop.ts` — single `process.stderr.write` change. Keep the prior blank line before the banner so iterations are visually separable.
+
+Also retitle `[sandcastle] log → …` to `dim("log → " + logPath)` (drop the prefix; the banner already establishes context).
+
+### 4. Docker stderr noise (`runner.ts:230`)
+
+`[docker]` lines today dump everything Docker writes (image pull progress, TLS warnings, etc.). Keep the ring-buffer tail for the failure path, but route live lines through `dim("docker  " + line)` instead of `[docker] line` so they recede visually. No filtering — same information, just lower contrast.
+
+### 5. Final completion line (`loop.ts:38`)
+
+`Ralph complete after N iterations.` → `green("●") " " bold("Ralph complete") dim(" after " + N + " iterations")`. Stays on stdout (it's a terminal status, not an event).
+
+## Files touched
+
+- `packages/core/src/runner.ts` — add style helpers, rewrite `renderEvent`, thread tool-use-id map through `streamDocker`, soften `[docker]` prefix, soften `log →` line.
+- `packages/core/src/loop.ts` — banner + completion line.
+
+No new files. No package.json changes. No deps added.
+
+## Verification
+
+1. `pnpm -r typecheck` — must pass; the only type surface that changes is the local map inside `streamDocker`.
+2. Smoke run interactively against a small target repo:
+   ```bash
+   pnpm -r build
+   RALPH_WORKSPACE=/tmp/target ralph-ghafk 1
+   ```
+   Expect: colored banner, cyan `●` tool calls, `⎿ ✓` results pairing with the tool above, dim thinking marker, dim docker chatter, no double-printed iteration text. Confirm tool name on result line matches the tool above it.
+3. Pipe-to-file test (forces plain branch):
+   ```bash
+   ralph-ghafk 1 2>&1 | tee run.log
+   ```
+   `run.log` must contain zero `\x1b[` escape sequences (`grep -Pc '\x1b\['` returns 0). Symbols degrade to `*` / `>`.
+4. `NO_COLOR=1 ralph-ghafk 1` — same plain output even on a TTY.
+5. Inspect a fresh `.ralph-tmp/logs/*.ndjson` — content must be byte-identical to a pre-change run for the same prompt (rendering layer doesn't touch the log file).
+6. Force a tool failure (e.g. point at a workspace with a broken `gh` config) — confirm `✗` line renders in red and the stderr tail still surfaces on non-zero exit.
+
+## Out of scope (deferred)
+
+- Surfacing usage tokens / cost / duration in a final summary line. Claude Code's stream-json doesn't always emit these — would require either a stage-end accumulator or upstream CLI changes. Worth a follow-up.
+- Per-subagent color rotation (Claude Code's 8-color palette). Ralph only runs one stage at a time, so no parallel tasks to disambiguate.
+- Replacing `console.error(e?.stack ?? e)` in the bins with a styled crash dump.

--- a/docs/plans/cli-output-prettifier.md
+++ b/docs/plans/cli-output-prettifier.md
@@ -21,7 +21,7 @@ Add a small module-local style layer. No new prod deps (matches existing "small 
 
 ```ts
 const USE_COLOR =
-  process.stdout.isTTY === true &&
+  process.stderr.isTTY === true &&
   process.env.NO_COLOR == null &&
   process.env.TERM !== "dumb";
 

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { renderTemplate } from "./render.js";
-import { ensureImage, runStage } from "./runner.js";
+import { ensureImage, runStage, USE_COLOR, dim, bold, green, SYM } from "./runner.js";
 import type { Stage } from "./stages.js";
 
 const SENTINEL = "<promise>NO MORE TASKS</promise>";
@@ -26,16 +26,19 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     let gateResult = "";
     for (let s = 0; s < stages.length; s++) {
       const stage = stages[s];
-      process.stderr.write(
-        `\n[sandcastle] iteration ${i}/${iterations} stage ${s + 1}/${stages.length} (${stage.name})\n`
-      );
+      const banner = USE_COLOR
+        ? `${dim("━━━")} ${bold(`iteration ${i}/${iterations}`)} ${dim("·")} ${bold(stage.name)} ${dim(`(stage ${s + 1}/${stages.length})`)} ${dim("━━━")}`
+        : `== iteration ${i}/${iterations} · ${stage.name} (stage ${s + 1}/${stages.length}) ==`;
+      process.stderr.write(`\n${banner}\n`);
       const templatePath = join(sandcastleDir, "templates", stage.template);
       const prompt = renderTemplate(templatePath, { INPUTS: inputs }, { cwd: workspaceDir });
       const result = await runStage(stage, prompt, workspaceDir, i);
       if (s === 0) {
         gateResult = result;
         if (gateResult.includes(SENTINEL)) {
-          console.log(`Ralph complete after ${i} iterations.`);
+          process.stdout.write(
+            `${green(SYM.bullet)} ${bold("Ralph complete")}${dim(` after ${i} iterations`)}\n`
+          );
           return;
         }
       }

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { renderTemplate } from "./render.js";
-import { ensureImage, runStage, USE_COLOR, dim, bold, green, SYM } from "./runner.js";
+import { ensureImage, runStage, USE_COLOR, dim, bold, greenOut, boldOut, dimOut, SYM_OUT } from "./runner.js";
 import type { Stage } from "./stages.js";
 
 const SENTINEL = "<promise>NO MORE TASKS</promise>";
@@ -27,8 +27,8 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     for (let s = 0; s < stages.length; s++) {
       const stage = stages[s];
       const banner = USE_COLOR
-        ? `${dim("━━━")} ${bold(`iteration ${i}/${iterations}`)} ${dim("·")} ${bold(stage.name)} ${dim(`(stage ${s + 1}/${stages.length})`)} ${dim("━━━")}`
-        : `== iteration ${i}/${iterations} · ${stage.name} (stage ${s + 1}/${stages.length}) ==`;
+        ? `${dim("\u2501\u2501\u2501")} ${bold(`iteration ${i}/${iterations}`)} ${dim("\u00b7")} ${bold(stage.name)} ${dim(`(stage ${s + 1}/${stages.length})`)} ${dim("\u2501\u2501\u2501")}`
+        : `== iteration ${i}/${iterations} \u00b7 ${stage.name} (stage ${s + 1}/${stages.length}) ==`;
       process.stderr.write(`\n${banner}\n`);
       const templatePath = join(sandcastleDir, "templates", stage.template);
       const prompt = renderTemplate(templatePath, { INPUTS: inputs }, { cwd: workspaceDir });
@@ -36,9 +36,8 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
       if (s === 0) {
         gateResult = result;
         if (gateResult.includes(SENTINEL)) {
-          process.stdout.write(
-            `${green(SYM.bullet)} ${bold("Ralph complete")}${dim(` after ${i} iterations`)}\n`
-          );
+          const msg = greenOut(SYM_OUT.bullet) + " " + boldOut("Ralph complete") + dimOut(" after " + i + " iterations");
+          process.stdout.write(msg + "\n");
           return;
         }
       }

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -19,7 +19,29 @@ export const IMAGE_REF =
   "docker.io/daonhan/ralph-sandbox:latest";
 const STDERR_TAIL_LINES = 40;
 const TOOL_INPUT_PREVIEW = 200;
-const TOOL_RESULT_PREVIEW = 400;
+const TOOL_RESULT_PREVIEW = 120;
+const TOOL_ERROR_PREVIEW = 400;
+
+/* ── TTY-gated styling ────────────────────────────────────────────────── */
+
+const USE_COLOR =
+  process.stderr.isTTY === true &&
+  process.env.NO_COLOR == null &&
+  process.env.TERM !== "dumb";
+
+const c = (code: string, s: string): string =>
+  USE_COLOR ? `\x1b[${code}m${s}\x1b[0m` : s;
+const dim = (s: string): string => c("2", s);
+const bold = (s: string): string => c("1", s);
+const cyan = (s: string): string => c("36", s);
+const green = (s: string): string => c("32", s);
+const red = (s: string): string => c("31", s);
+
+const SYM = USE_COLOR
+  ? { bullet: "●", cont: "⎿", check: "✓", cross: "✗", rule: "━" }
+  : { bullet: "*", cont: "  >", check: "ok", cross: "FAIL", rule: "=" };
+
+export { USE_COLOR, dim, bold, cyan, green, red, SYM };
 
 type AssistantBlock = {
   type: string;
@@ -78,13 +100,13 @@ export function ensureImage(buildContext?: string): void {
 
   if (hasLocal && !floating) return;
 
-  process.stderr.write(`[sandcastle] Pulling image ${IMAGE_REF}\n`);
+  process.stderr.write(`${dim("pulling")} ${IMAGE_REF}\n`);
   const pull = spawnSync("docker", ["pull", IMAGE_REF], { stdio: "inherit" });
   if (pull.status === 0) return;
 
   if (hasLocal) {
     process.stderr.write(
-      `[sandcastle] pull failed; using cached local copy of ${IMAGE_REF}\n`
+      `${dim("pull failed; using cached local copy of")} ${IMAGE_REF}\n`
     );
     return;
   }
@@ -103,7 +125,7 @@ export function ensureImage(buildContext?: string): void {
     );
   }
   process.stderr.write(
-    `[sandcastle] pull failed; building ${IMAGE_REF} from ${buildContext}\n`
+    `${dim("pull failed; building")} ${IMAGE_REF} ${dim("from")} ${buildContext}\n`
   );
   const build = spawnSync(
     "docker",
@@ -140,7 +162,7 @@ export async function runStage(
 
   writeFileSync(promptHostPath, renderedPrompt, "utf8");
 
-  process.stderr.write(`[sandcastle] log → ${logPath}\n`);
+  process.stderr.write(`${dim("log → " + logPath)}\n`);
 
   try {
     const args = [
@@ -199,6 +221,7 @@ export async function runStage(
 function streamDocker(args: string[], logPath: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const logFd = openSync(logPath, "a");
+    const toolMap = new Map<string, ToolTrack>();
 
     const child = spawn("docker", args, {
       stdio: ["ignore", "pipe", "pipe"],
@@ -219,7 +242,7 @@ function streamDocker(args: string[], logPath: string): Promise<string> {
       } catch {
         return;
       }
-      renderEvent(parsed);
+      renderEvent(parsed, toolMap);
       if (parsed.type === "result") {
         const r = (parsed as { result?: string }).result;
         if (typeof r === "string") finalResult = r;
@@ -230,7 +253,7 @@ function streamDocker(args: string[], logPath: string): Promise<string> {
     rlErr.on("line", (line) => {
       stderrTail.push(line);
       if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
-      process.stderr.write(`[docker] ${line}\n`);
+      process.stderr.write(`${dim("docker  " + line)}\n`);
     });
 
     child.on("error", (err) => {
@@ -250,14 +273,21 @@ function streamDocker(args: string[], logPath: string): Promise<string> {
   });
 }
 
-function renderEvent(ev: StreamJson): void {
+type ToolTrack = { name: string; startedAt: number };
+
+function renderEvent(
+  ev: StreamJson,
+  toolMap: Map<string, ToolTrack>
+): void {
   switch (ev.type) {
     case "system": {
       const sub = (ev as { subtype?: string }).subtype;
       if (sub === "init") {
         const model = (ev as { model?: string }).model ?? "?";
         const cwd = (ev as { cwd?: string }).cwd ?? "?";
-        process.stderr.write(`[init] model=${model} cwd=${cwd}\n`);
+        process.stderr.write(
+          `${dim("───")} ${bold("init")} ${dim(`model=${model} cwd=${cwd}`)}\n`
+        );
       }
       return;
     }
@@ -267,14 +297,22 @@ function renderEvent(ev: StreamJson): void {
         [];
       for (const block of content) {
         if (block.type === "text" && typeof block.text === "string") {
-          process.stdout.write(block.text.replace(/\n/g, "\r\n") + "\r\n\n");
+          const lines = block.text.split("\n");
+          const formatted = lines
+            .map((l, idx) => (idx === 0 ? `${bold(cyan(SYM.bullet))} ${l}` : `  ${l}`))
+            .join("\r\n");
+          process.stdout.write(formatted + "\r\n\n");
         } else if (block.type === "thinking") {
-          // Thinking blocks are usually long; show one marker line, not full text.
-          process.stderr.write(`[thinking]\n`);
+          process.stderr.write(`${dim(SYM.bullet + " thinking…")}\n`);
         } else if (block.type === "tool_use") {
           const name = block.name ?? "?";
           const preview = previewInput(name, block.input);
-          process.stderr.write(`[tool] ${name} ${preview}\n`);
+          if (block.id) {
+            toolMap.set(block.id, { name, startedAt: Date.now() });
+          }
+          process.stderr.write(
+            `${cyan(SYM.bullet)} ${bold(name)} ${dim(preview)}\n`
+          );
         }
       }
       return;
@@ -285,10 +323,19 @@ function renderEvent(ev: StreamJson): void {
       for (const block of content) {
         if (block.type !== "tool_result") continue;
         const text = stringifyToolResult(block.content);
+        const tracked = block.tool_use_id
+          ? toolMap.get(block.tool_use_id)
+          : undefined;
+        const toolName = tracked?.name ?? "tool";
+        const elapsed = tracked
+          ? ` (${Date.now() - tracked.startedAt}ms)`
+          : "";
+        if (block.tool_use_id) toolMap.delete(block.tool_use_id);
+
         if (block.is_error) {
-          const snippet = text.slice(0, TOOL_RESULT_PREVIEW * 2);
+          const snippet = text.slice(0, TOOL_ERROR_PREVIEW);
           process.stderr.write(
-            `[tool:error] ${snippet}${text.length > snippet.length ? " …" : ""}\n`
+            `${dim(SYM.cont)} ${red(SYM.cross)} ${bold(toolName)}${red(" failed")}\n  ${red(snippet)}${text.length > snippet.length ? " …" : ""}\n`
           );
         } else {
           const snippet = text
@@ -296,7 +343,7 @@ function renderEvent(ev: StreamJson): void {
             .trim()
             .slice(0, TOOL_RESULT_PREVIEW);
           process.stderr.write(
-            `[tool:ok] ${snippet}${text.length > snippet.length ? " …" : ""}\n`
+            `${dim(SYM.cont)} ${green(SYM.check)} ${bold(toolName)}${dim(elapsed)} ${dim(snippet)}${text.length > snippet.length ? " …" : ""}\n`
           );
         }
       }
@@ -304,7 +351,7 @@ function renderEvent(ev: StreamJson): void {
     }
     case "result": {
       const isError = (ev as { is_error?: boolean }).is_error;
-      if (isError) process.stderr.write(`[result] is_error=true\n`);
+      if (isError) process.stderr.write(`${red(SYM.bullet + " result errored")}\n`);
       return;
     }
     default:

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -24,24 +24,42 @@ const TOOL_ERROR_PREVIEW = 400;
 
 /* ── TTY-gated styling ────────────────────────────────────────────────── */
 
+const NO_COLOR_ENV =
+  process.env.NO_COLOR != null || process.env.TERM === "dumb";
+
+/** Controls ANSI codes on stderr (tool events, banners, docker output). */
 const USE_COLOR =
-  process.stderr.isTTY === true &&
-  process.env.NO_COLOR == null &&
-  process.env.TERM !== "dumb";
+  process.stderr.isTTY === true && !NO_COLOR_ENV;
+
+/** Controls ANSI codes on stdout (assistant text bullets, completion line).
+ *  Separate from USE_COLOR so `ralph-ghafk 1 > out.txt` stays clean even
+ *  when stderr is still a TTY. */
+const USE_COLOR_STDOUT =
+  process.stdout.isTTY === true && !NO_COLOR_ENV;
 
 const c = (code: string, s: string): string =>
   USE_COLOR ? `\x1b[${code}m${s}\x1b[0m` : s;
+const cOut = (code: string, s: string): string =>
+  USE_COLOR_STDOUT ? `\x1b[${code}m${s}\x1b[0m` : s;
 const dim = (s: string): string => c("2", s);
 const bold = (s: string): string => c("1", s);
 const cyan = (s: string): string => c("36", s);
 const green = (s: string): string => c("32", s);
 const red = (s: string): string => c("31", s);
+const boldOut = (s: string): string => cOut("1", s);
+const cyanOut = (s: string): string => cOut("36", s);
+const greenOut = (s: string): string => cOut("32", s);
+const dimOut = (s: string): string => cOut("2", s);
 
 const SYM = USE_COLOR
-  ? { bullet: "●", cont: "⎿", check: "✓", cross: "✗", rule: "━" }
-  : { bullet: "*", cont: "  >", check: "ok", cross: "FAIL", rule: "=" };
+  ? { bullet: "●", cont: "⎿", check: "✓", cross: "✗", rule: "━", ellip: "…" }
+  : { bullet: "*", cont: "  >", check: "ok", cross: "FAIL", rule: "=", ellip: "..." };
 
-export { USE_COLOR, dim, bold, cyan, green, red, SYM };
+const SYM_OUT = USE_COLOR_STDOUT
+  ? { bullet: "●" }
+  : { bullet: "*" };
+
+export { USE_COLOR, USE_COLOR_STDOUT, dim, bold, cyan, green, red, SYM, greenOut, boldOut, dimOut, SYM_OUT };
 
 type AssistantBlock = {
   type: string;
@@ -299,11 +317,11 @@ function renderEvent(
         if (block.type === "text" && typeof block.text === "string") {
           const lines = block.text.split("\n");
           const formatted = lines
-            .map((l, idx) => (idx === 0 ? `${bold(cyan(SYM.bullet))} ${l}` : `  ${l}`))
+            .map((l, idx) => (idx === 0 ? `${boldOut(cyanOut(SYM_OUT.bullet))} ${l}` : `  ${l}`))
             .join("\r\n");
           process.stdout.write(formatted + "\r\n\n");
         } else if (block.type === "thinking") {
-          process.stderr.write(`${dim(SYM.bullet + " thinking…")}\n`);
+          process.stderr.write(`${dim(SYM.bullet + " thinking" + SYM.ellip)}\n`);
         } else if (block.type === "tool_use") {
           const name = block.name ?? "?";
           const preview = previewInput(name, block.input);
@@ -333,9 +351,12 @@ function renderEvent(
         if (block.tool_use_id) toolMap.delete(block.tool_use_id);
 
         if (block.is_error) {
-          const snippet = text.slice(0, TOOL_ERROR_PREVIEW);
+          const snippet = text
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, TOOL_ERROR_PREVIEW);
           process.stderr.write(
-            `${dim(SYM.cont)} ${red(SYM.cross)} ${bold(toolName)}${red(" failed")}\n  ${red(snippet)}${text.length > snippet.length ? " …" : ""}\n`
+            `${dim(SYM.cont)} ${red(SYM.cross)} ${bold(toolName)}${red(" failed")}\n  ${red(snippet)}${text.length > snippet.length ? " " + SYM.ellip : ""}\n`
           );
         } else {
           const snippet = text
@@ -343,7 +364,7 @@ function renderEvent(
             .trim()
             .slice(0, TOOL_RESULT_PREVIEW);
           process.stderr.write(
-            `${dim(SYM.cont)} ${green(SYM.check)} ${bold(toolName)}${dim(elapsed)} ${dim(snippet)}${text.length > snippet.length ? " …" : ""}\n`
+            `${dim(SYM.cont)} ${green(SYM.check)} ${bold(toolName)}${dim(elapsed)} ${dim(snippet)}${text.length > snippet.length ? " " + SYM.ellip : ""}\n`
           );
         }
       }
@@ -400,5 +421,5 @@ function stringifyToolResult(content: unknown): string {
 
 function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
-  return s.slice(0, max - 1) + "…";
+  return s.slice(0, max - 1) + SYM.ellip;
 }


### PR DESCRIPTION
Improve Ralph CLI output readability by rendering stream-json events with concise, styled terminal lines.

This adds an opinionated event renderer for assistant text/tool calls/tool results, includes timing and compact previews for tool I/O, and keeps raw NDJSON logs for deep debugging.

Why:
- Current output is hard to scan during long implementer/reviewer loops.
- A cleaner event stream makes progress, failures, and tool activity easier to follow in real time.

Main changes:
- Add TTY-aware color/symbol formatting helpers and event rendering in packages/core/src/runner.ts.
- Keep streaming behavior and final result capture while improving stderr/stdout presentation.
- Minor loop-stage messaging cleanup in packages/core/src/loop.ts.
- Add planning notes in docs/plans/cli-output-prettifier.md.

Notes:
- Uses plain ASCII fallbacks when color/TTY is unavailable.
- Preserves .ralph-tmp/logs NDJSON output for diagnostics.