### PR TITLE
Spill oversized template output into side files

### DIFF
--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -1,7 +1,17 @@
-import { join } from "node:path";
+import { join, posix } from "node:path";
 
 import { renderTemplate } from "./render.js";
-import { ensureImage, runStage, USE_COLOR, dim, bold, greenOut, boldOut, dimOut, SYM_OUT } from "./runner.js";
+import {
+  ensureImage,
+  runStage,
+  USE_COLOR,
+  dim,
+  bold,
+  greenOut,
+  boldOut,
+  dimOut,
+  SYM_OUT,
+} from "./runner.js";
 import type { Stage } from "./stages.js";
 
 const SENTINEL = "<promise>NO MORE TASKS</promise>";
@@ -18,7 +28,8 @@ export type LoopOptions = {
 };
 
 export async function runLoop(opts: LoopOptions): Promise<void> {
-  const { stages, inputs, iterations, ralphDir, workspaceDir, sandcastleDir } = opts;
+  const { stages, inputs, iterations, ralphDir, workspaceDir, sandcastleDir } =
+    opts;
 
   ensureImage(ralphDir);
 
@@ -31,12 +42,29 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
         : `== iteration ${i}/${iterations} \u00b7 ${stage.name} (stage ${s + 1}/${stages.length}) ==`;
       process.stderr.write(`\n${banner}\n`);
       const templatePath = join(sandcastleDir, "templates", stage.template);
-      const prompt = renderTemplate(templatePath, { INPUTS: inputs }, { cwd: workspaceDir });
-      const result = await runStage(stage, prompt, workspaceDir, i);
+      const spillRel = `spill-${process.pid}-${i}-${s}-${Date.now()}`;
+      const spillHostDir = join(workspaceDir, ".ralph-tmp", spillRel);
+      const spillRefPath = posix.join(".ralph-tmp", spillRel);
+      const prompt = renderTemplate(
+        templatePath,
+        { INPUTS: inputs },
+        { cwd: workspaceDir, spillHostDir, spillRefPath }
+      );
+      const result = await runStage(
+        stage,
+        prompt,
+        workspaceDir,
+        i,
+        spillHostDir
+      );
       if (s === 0) {
         gateResult = result;
         if (gateResult.includes(SENTINEL)) {
-          const msg = greenOut(SYM_OUT.bullet) + " " + boldOut("Ralph complete") + dimOut(" after " + i + " iterations");
+          const msg =
+            greenOut(SYM_OUT.bullet) +
+            " " +
+            boldOut("Ralph complete") +
+            dimOut(" after " + i + " iterations");
           process.stdout.write(msg + "\n");
           return;
         }

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -59,6 +59,21 @@ export function renderTemplate(
           `@spill:${name} used but spillHostDir/spillRefPath not provided to renderTemplate`
         );
       }
+      // Reject any name that could escape spillHostDir. Templates are trusted
+      // (shipped in the npm tarball) but defense-in-depth — keep file writes
+      // confined to the per-iteration spill dir.
+      if (
+        name.includes("/") ||
+        name.includes("\\") ||
+        name === "." ||
+        name === ".." ||
+        name.includes("..") ||
+        isAbsolute(name)
+      ) {
+        throw new Error(
+          `@spill:${name} — name must be a plain filename (no path separators, no ..)`
+        );
+      }
       const tryMode = q === "?";
       let cmd = body;
       let fallback = "";

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -1,11 +1,15 @@
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, isAbsolute, resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 // Order matters: !?`...` (try-shell w/ ||| fallback) must match before plain !`...`.
 const SHELL_TRY_TAG = /!\?`([^`]+)`/g;
 const SHELL_TAG = /!`([^`]+)`/g;
 const INCLUDE_TAG = /@include:([^\s`)]+)/g;
+// @spill[?]:<name>=`cmd[|||fallback]` — runs cmd, writes output to spillHostDir/<name>,
+// substitutes the container-relative file path in the prompt. The `?` form treats
+// non-zero exits as success and writes the fallback string instead of throwing.
+const SPILL_TAG = /@spill(\??):([^\s=]+)=`([^`]+)`/g;
 const INPUTS_TAG = /\{\{\s*INPUTS\s*\}\}/g;
 const TRY_SEP = "|||";
 
@@ -15,6 +19,10 @@ export type RenderVars = {
 
 export type RenderOptions = {
   cwd?: string;
+  // Where @spill writes files on the host. Required if templates use @spill.
+  spillHostDir?: string;
+  // POSIX path the agent uses to reach spillHostDir from its working dir.
+  spillRefPath?: string;
 };
 
 function resolveShell(): string {
@@ -43,23 +51,63 @@ export function renderTemplate(
     return readFileSync(target, "utf8").replace(/\r?\n$/, "");
   });
 
-  const afterShellTry = afterInclude.replace(SHELL_TRY_TAG, (_match, body: string) => {
-    const sep = body.lastIndexOf(TRY_SEP);
-    const cmd = sep >= 0 ? body.slice(0, sep) : body;
-    const fallback = sep >= 0 ? body.slice(sep + TRY_SEP.length) : "";
-    try {
-      const out = execSync(cmd, {
-        shell,
-        encoding: "utf8",
-        maxBuffer: 64 * 1024 * 1024,
-        cwd: opts.cwd,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      return out.replace(/\r?\n$/, "");
-    } catch {
-      return fallback;
+  const afterSpill = afterInclude.replace(
+    SPILL_TAG,
+    (_match, q: string, name: string, body: string) => {
+      if (!opts.spillHostDir || !opts.spillRefPath) {
+        throw new Error(
+          `@spill:${name} used but spillHostDir/spillRefPath not provided to renderTemplate`
+        );
+      }
+      const tryMode = q === "?";
+      let cmd = body;
+      let fallback = "";
+      if (tryMode) {
+        const sep = body.lastIndexOf(TRY_SEP);
+        if (sep >= 0) {
+          cmd = body.slice(0, sep);
+          fallback = body.slice(sep + TRY_SEP.length);
+        }
+      }
+      let out: string;
+      try {
+        out = execSync(cmd, {
+          shell,
+          encoding: "utf8",
+          maxBuffer: 64 * 1024 * 1024,
+          cwd: opts.cwd,
+          stdio: ["ignore", "pipe", tryMode ? "ignore" : "pipe"],
+        });
+      } catch (err) {
+        if (!tryMode) throw err;
+        out = fallback;
+      }
+      mkdirSync(opts.spillHostDir, { recursive: true });
+      writeFileSync(join(opts.spillHostDir, name), out, "utf8");
+      return `./${opts.spillRefPath}/${name}`;
     }
-  });
+  );
+
+  const afterShellTry = afterSpill.replace(
+    SHELL_TRY_TAG,
+    (_match, body: string) => {
+      const sep = body.lastIndexOf(TRY_SEP);
+      const cmd = sep >= 0 ? body.slice(0, sep) : body;
+      const fallback = sep >= 0 ? body.slice(sep + TRY_SEP.length) : "";
+      try {
+        const out = execSync(cmd, {
+          shell,
+          encoding: "utf8",
+          maxBuffer: 64 * 1024 * 1024,
+          cwd: opts.cwd,
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+        return out.replace(/\r?\n$/, "");
+      } catch {
+        return fallback;
+      }
+    }
+  );
 
   const afterShell = afterShellTry.replace(SHELL_TAG, (_match, cmd: string) => {
     const out = execSync(cmd, {

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -28,14 +28,12 @@ const NO_COLOR_ENV =
   process.env.NO_COLOR != null || process.env.TERM === "dumb";
 
 /** Controls ANSI codes on stderr (tool events, banners, docker output). */
-const USE_COLOR =
-  process.stderr.isTTY === true && !NO_COLOR_ENV;
+const USE_COLOR = process.stderr.isTTY === true && !NO_COLOR_ENV;
 
 /** Controls ANSI codes on stdout (assistant text bullets, completion line).
  *  Separate from USE_COLOR so `ralph-ghafk 1 > out.txt` stays clean even
  *  when stderr is still a TTY. */
-const USE_COLOR_STDOUT =
-  process.stdout.isTTY === true && !NO_COLOR_ENV;
+const USE_COLOR_STDOUT = process.stdout.isTTY === true && !NO_COLOR_ENV;
 
 const c = (code: string, s: string): string =>
   USE_COLOR ? `\x1b[${code}m${s}\x1b[0m` : s;
@@ -53,13 +51,31 @@ const dimOut = (s: string): string => cOut("2", s);
 
 const SYM = USE_COLOR
   ? { bullet: "●", cont: "⎿", check: "✓", cross: "✗", rule: "━", ellip: "…" }
-  : { bullet: "*", cont: "  >", check: "ok", cross: "FAIL", rule: "=", ellip: "..." };
+  : {
+      bullet: "*",
+      cont: "  >",
+      check: "ok",
+      cross: "FAIL",
+      rule: "=",
+      ellip: "...",
+    };
 
-const SYM_OUT = USE_COLOR_STDOUT
-  ? { bullet: "●" }
-  : { bullet: "*" };
+const SYM_OUT = USE_COLOR_STDOUT ? { bullet: "●" } : { bullet: "*" };
 
-export { USE_COLOR, USE_COLOR_STDOUT, dim, bold, cyan, green, red, SYM, greenOut, boldOut, dimOut, SYM_OUT };
+export {
+  USE_COLOR,
+  USE_COLOR_STDOUT,
+  dim,
+  bold,
+  cyan,
+  green,
+  red,
+  SYM,
+  greenOut,
+  boldOut,
+  dimOut,
+  SYM_OUT,
+};
 
 type AssistantBlock = {
   type: string;
@@ -161,7 +177,8 @@ export async function runStage(
   stage: Stage,
   renderedPrompt: string,
   workspaceDir: string,
-  iteration: number
+  iteration: number,
+  spillHostDir?: string
 ): Promise<string> {
   const tmpHostDir = join(workspaceDir, ".ralph-tmp");
   mkdirSync(tmpHostDir, { recursive: true });
@@ -233,6 +250,7 @@ export async function runStage(
     return await streamDocker(args, logPath);
   } finally {
     rmSync(promptHostPath, { force: true });
+    if (spillHostDir) rmSync(spillHostDir, { recursive: true, force: true });
   }
 }
 
@@ -293,10 +311,7 @@ function streamDocker(args: string[], logPath: string): Promise<string> {
 
 type ToolTrack = { name: string; startedAt: number };
 
-function renderEvent(
-  ev: StreamJson,
-  toolMap: Map<string, ToolTrack>
-): void {
+function renderEvent(ev: StreamJson, toolMap: Map<string, ToolTrack>): void {
   switch (ev.type) {
     case "system": {
       const sub = (ev as { subtype?: string }).subtype;
@@ -317,11 +332,15 @@ function renderEvent(
         if (block.type === "text" && typeof block.text === "string") {
           const lines = block.text.split("\n");
           const formatted = lines
-            .map((l, idx) => (idx === 0 ? `${boldOut(cyanOut(SYM_OUT.bullet))} ${l}` : `  ${l}`))
+            .map((l, idx) =>
+              idx === 0 ? `${boldOut(cyanOut(SYM_OUT.bullet))} ${l}` : `  ${l}`
+            )
             .join("\r\n");
           process.stdout.write(formatted + "\r\n\n");
         } else if (block.type === "thinking") {
-          process.stderr.write(`${dim(SYM.bullet + " thinking" + SYM.ellip)}\n`);
+          process.stderr.write(
+            `${dim(SYM.bullet + " thinking" + SYM.ellip)}\n`
+          );
         } else if (block.type === "tool_use") {
           const name = block.name ?? "?";
           const preview = previewInput(name, block.input);
@@ -345,9 +364,7 @@ function renderEvent(
           ? toolMap.get(block.tool_use_id)
           : undefined;
         const toolName = tracked?.name ?? "tool";
-        const elapsed = tracked
-          ? ` (${Date.now() - tracked.startedAt}ms)`
-          : "";
+        const elapsed = tracked ? ` (${Date.now() - tracked.startedAt}ms)` : "";
         if (block.tool_use_id) toolMap.delete(block.tool_use_id);
 
         if (block.is_error) {
@@ -372,7 +389,8 @@ function renderEvent(
     }
     case "result": {
       const isError = (ev as { is_error?: boolean }).is_error;
-      if (isError) process.stderr.write(`${red(SYM.bullet + " result errored")}\n`);
+      if (isError)
+        process.stderr.write(`${red(SYM.bullet + " result errored")}\n`);
       return;
     }
     default:

--- a/packages/core/templates/ghafk.md
+++ b/packages/core/templates/ghafk.md
@@ -4,10 +4,18 @@
 
 </commits>
 
-<issues>
+<issues-summary>
 
-!?`gh issue list --state open --json number,title,body,comments|||[]`
+!?`gh issue list --state open --limit 50 --json number,title,labels|||[]`
 
-</issues>
+</issues-summary>
+
+<issues-full-file>
+
+Full issue bodies + comments spilled to: @spill?:issues.json=`gh issue list --state open --limit 50 --json number,title,body,labels,comments|||[]`
+
+Read that file with `Read` (use `offset`/`limit` if it is large) to get bodies and comments before picking a task. The `<issues-summary>` block above is the lean index for triage.
+
+</issues-full-file>
 
 @include:ghprompt.md

--- a/packages/core/templates/ghprompt.md
+++ b/packages/core/templates/ghprompt.md
@@ -1,8 +1,11 @@
 # ISSUES
 
-GitHub issues are provided at start of context. Parse it to get open issues with their bodies and comments.
+Two views of open GitHub issues are provided at the start of context:
 
-You will work on the AFK issues only, not the HITL ones.
+- `<issues-summary>` — inline lean index (number, title, labels). Use this to triage and pick a task.
+- `<issues-full-file>` — path to a spilled JSON file containing bodies + comments. `Read` that file (with `offset`/`limit` if it is large) once you have picked an issue you want to act on.
+
+You will work on the AFK issues only, not the HITL ones. Label filtering uses the `labels` field in the summary.
 
 You've also been passed a file containing the last few commits. Review these to understand what work has been done.
 

--- a/packages/core/templates/review.md
+++ b/packages/core/templates/review.md
@@ -14,7 +14,9 @@
 
 !?`git show --stat HEAD|||No diff`
 
-!?`git show HEAD | head -c 200000|||No diff body`
+Full patch spilled to: @spill?:head.diff=`git show HEAD|||No diff body`
+
+Read that file with `Read` (use `offset`/`limit` for large diffs) before reviewing.
 
 </latest-diff>
 
@@ -35,6 +37,7 @@ If `<head>` shows `(no commits)` or HEAD is unchanged from the previous iteratio
 # ACTION
 
 If defects found:
+
 - Fix them directly in the working tree.
 - Run feedback loops:
   - Frontend / Node: `pnpm run test`, `pnpm run typecheck`

--- a/scripts/smoke-render.mjs
+++ b/scripts/smoke-render.mjs
@@ -26,7 +26,7 @@ writeFileSync(
     "@include:incl.md",
     "</include>",
     "<shell>!?`echo HELLO|||FALLBACK`</shell>",
-    "<shellfail>!?`this-cmd-does-not-exist|||FELLBACK`</shellfail>",
+    "<shellfail>!?`this-cmd-does-not-exist|||FALLBACK`</shellfail>",
     '<spill>@spill?:big.json=`echo {\\"k\\":\\"v\\"}|||FB`</spill>',
     "<spillfail>@spill?:bad.json=`this-cmd-does-not-exist|||FB-FALLBACK`</spillfail>",
   ].join("\n")
@@ -51,7 +51,7 @@ const out = renderTemplate(
 check("INPUTS substituted", out.includes("<inputs>INPUT-VAL</inputs>"));
 check("@include inlined", out.includes("INCLUDED-CONTENT"));
 check("!? shell ok", /<shell>HELLO<\/shell>/.test(out));
-check("!? shell fallback", /<shellfail>FELLBACK<\/shellfail>/.test(out));
+check("!? shell fallback", /<shellfail>FALLBACK<\/shellfail>/.test(out));
 check(
   "@spill ok → path inlined",
   out.includes(`<spill>./${spillRefPath}/big.json</spill>`)
@@ -88,6 +88,33 @@ try {
   check("missing spill opts throws", false, "did not throw");
 } catch (e) {
   check("missing spill opts throws", /spillHostDir/.test(String(e)));
+}
+
+// Path-traversal guard — names with separators / .. / absolute must be rejected.
+const evilNames = [
+  "../escape.txt",
+  "..\\escape.txt",
+  "sub/dir.txt",
+  "/etc/passwd",
+  "..",
+];
+for (const evil of evilNames) {
+  const evilTpl = join(work, `evil-${encodeURIComponent(evil)}.md`);
+  writeFileSync(evilTpl, `@spill?:${evil}=\`echo X|||fb\``);
+  try {
+    renderTemplate(
+      evilTpl,
+      { INPUTS: "" },
+      { cwd: work, spillHostDir, spillRefPath }
+    );
+    check(`traversal rejected: ${evil}`, false, "did not throw");
+  } catch (e) {
+    check(
+      `traversal rejected: ${evil}`,
+      /plain filename/.test(String(e)),
+      `wrong error: ${e}`
+    );
+  }
 }
 
 rmSync(work, { recursive: true, force: true });

--- a/scripts/smoke-render.mjs
+++ b/scripts/smoke-render.mjs
@@ -1,0 +1,99 @@
+// Smoke test for render.ts @spill tag + existing tags.
+// Run from repo root after `pnpm -r build`.
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, posix } from "node:path";
+import { renderTemplate } from "../packages/core/dist/render.js";
+
+const work = mkdtempSync(join(tmpdir(), "ralph-smoke-"));
+const tpl = join(work, "tpl.md");
+const incl = join(work, "incl.md");
+const spillHostDir = join(work, ".ralph-tmp", "spill-test");
+const spillRefPath = posix.join(".ralph-tmp", "spill-test");
+
+writeFileSync(incl, "INCLUDED-CONTENT");
+writeFileSync(
+  tpl,
+  [
+    "<inputs>{{ INPUTS }}</inputs>",
+    "<include>",
+    "@include:incl.md",
+    "</include>",
+    "<shell>!?`echo HELLO|||FALLBACK`</shell>",
+    "<shellfail>!?`this-cmd-does-not-exist|||FELLBACK`</shellfail>",
+    '<spill>@spill?:big.json=`echo {\\"k\\":\\"v\\"}|||FB`</spill>',
+    "<spillfail>@spill?:bad.json=`this-cmd-does-not-exist|||FB-FALLBACK`</spillfail>",
+  ].join("\n")
+);
+
+let failures = 0;
+const check = (name, cond, detail) => {
+  if (cond) {
+    process.stdout.write(`ok    ${name}\n`);
+  } else {
+    process.stdout.write(`FAIL  ${name}${detail ? `\n      ${detail}` : ""}\n`);
+    failures++;
+  }
+};
+
+const out = renderTemplate(
+  tpl,
+  { INPUTS: "INPUT-VAL" },
+  { cwd: work, spillHostDir, spillRefPath }
+);
+
+check("INPUTS substituted", out.includes("<inputs>INPUT-VAL</inputs>"));
+check("@include inlined", out.includes("INCLUDED-CONTENT"));
+check("!? shell ok", /<shell>HELLO<\/shell>/.test(out));
+check("!? shell fallback", /<shellfail>FELLBACK<\/shellfail>/.test(out));
+check(
+  "@spill ok → path inlined",
+  out.includes(`<spill>./${spillRefPath}/big.json</spill>`)
+);
+check(
+  "@spill fallback → path inlined",
+  out.includes(`<spillfail>./${spillRefPath}/bad.json</spillfail>`)
+);
+
+const bigPath = join(spillHostDir, "big.json");
+const badPath = join(spillHostDir, "bad.json");
+check("@spill ok file exists", existsSync(bigPath));
+check("@spill fallback file exists", existsSync(badPath));
+if (existsSync(bigPath)) {
+  const c = readFileSync(bigPath, "utf8");
+  check(
+    "@spill ok content",
+    c.includes('"k":"v"'),
+    `got: ${JSON.stringify(c)}`
+  );
+}
+if (existsSync(badPath)) {
+  const c = readFileSync(badPath, "utf8");
+  check(
+    "@spill fallback content",
+    c === "FB-FALLBACK",
+    `got: ${JSON.stringify(c)}`
+  );
+}
+
+// Missing-opts guard.
+try {
+  renderTemplate(tpl, { INPUTS: "" }, { cwd: work });
+  check("missing spill opts throws", false, "did not throw");
+} catch (e) {
+  check("missing spill opts throws", /spillHostDir/.test(String(e)));
+}
+
+rmSync(work, { recursive: true, force: true });
+
+if (failures > 0) {
+  process.stderr.write(`\n${failures} failure(s)\n`);
+  process.exit(1);
+}
+process.stdout.write("\nall pass\n");

--- a/scripts/smoke-spill-large.mjs
+++ b/scripts/smoke-spill-large.mjs
@@ -11,7 +11,7 @@ const spillRel = "spill-X";
 const spillHostDir = join(work, ".ralph-tmp", spillRel);
 const spillRefPath = posix.join(".ralph-tmp", spillRel);
 
-// 200_000 byte payload via a shell loop. Use printf to avoid shell quirks.
+// 200_000 byte payload via `yes ... | head -c N` — portable on bash/git-bash.
 writeFileSync(
   tpl,
   [

--- a/scripts/smoke-spill-large.mjs
+++ b/scripts/smoke-spill-large.mjs
@@ -1,0 +1,42 @@
+// Prove that a LARGE shell output lands in the spill file and the prompt
+// only contains a short path reference (i.e. the cap-busting scenario is fixed).
+import { mkdtempSync, rmSync, writeFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, posix } from "node:path";
+import { renderTemplate } from "../packages/core/dist/render.js";
+
+const work = mkdtempSync(join(tmpdir(), "ralph-spill-large-"));
+const tpl = join(work, "tpl.md");
+const spillRel = "spill-X";
+const spillHostDir = join(work, ".ralph-tmp", spillRel);
+const spillRefPath = posix.join(".ralph-tmp", spillRel);
+
+// 200_000 byte payload via a shell loop. Use printf to avoid shell quirks.
+writeFileSync(
+  tpl,
+  [
+    "<pointer>",
+    "@spill?:big.txt=`yes XXXXXXXX | head -c 200000|||fb`",
+    "</pointer>",
+  ].join("\n")
+);
+
+const out = renderTemplate(
+  tpl,
+  { INPUTS: "" },
+  { cwd: work, spillHostDir, spillRefPath }
+);
+
+const spillSize = statSync(join(spillHostDir, "big.txt")).size;
+const promptSize = out.length;
+
+process.stdout.write(`prompt size: ${promptSize} chars\n`);
+process.stdout.write(`spill size:  ${spillSize} bytes\n`);
+process.stdout.write(`prompt body: ${JSON.stringify(out)}\n`);
+
+const ok = promptSize < 200 && spillSize >= 199000;
+process.stdout.write(
+  ok ? "\nok: prompt tiny, spill carries load\n" : "\nFAIL\n"
+);
+rmSync(work, { recursive: true, force: true });
+process.exit(ok ? 0 : 1);

--- a/scripts/smoke-spill-size.mjs
+++ b/scripts/smoke-spill-size.mjs
@@ -1,0 +1,27 @@
+// Verify heavy content actually lands in the spill file, not the prompt.
+import { mkdtempSync, rmSync, statSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, posix } from "node:path";
+import { renderTemplate } from "../packages/core/dist/render.js";
+
+const repo = process.cwd();
+const tplDir = join(repo, "packages", "core", "templates");
+
+const work = mkdtempSync(join(tmpdir(), "ralph-spill-size-"));
+const spillRel = "spill-test";
+const spillHostDir = join(work, ".ralph-tmp", spillRel);
+const spillRefPath = posix.join(".ralph-tmp", spillRel);
+
+renderTemplate(
+  join(tplDir, "ghafk.md"),
+  { INPUTS: "" },
+  { cwd: repo, spillHostDir, spillRefPath }
+);
+
+const f = join(spillHostDir, "issues.json");
+const size = statSync(f).size;
+const body = readFileSync(f, "utf8");
+process.stdout.write(`issues.json size: ${size} bytes\n`);
+process.stdout.write(`first 200 chars: ${body.slice(0, 200)}\n`);
+
+rmSync(work, { recursive: true, force: true });

--- a/scripts/smoke-templates.mjs
+++ b/scripts/smoke-templates.mjs
@@ -1,12 +1,6 @@
 // Render the real shipped templates against this repo. Verifies @spill paths,
 // inlined sections, and that prompts stay small.
-import {
-  mkdtempSync,
-  rmSync,
-  existsSync,
-  statSync,
-  readdirSync,
-} from "node:fs";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, posix } from "node:path";
 import { renderTemplate } from "../packages/core/dist/render.js";

--- a/scripts/smoke-templates.mjs
+++ b/scripts/smoke-templates.mjs
@@ -1,0 +1,94 @@
+// Render the real shipped templates against this repo. Verifies @spill paths,
+// inlined sections, and that prompts stay small.
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  statSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, posix } from "node:path";
+import { renderTemplate } from "../packages/core/dist/render.js";
+
+const repo = process.cwd();
+const tplDir = join(repo, "packages", "core", "templates");
+
+const cases = [
+  { name: "afk.md", inputs: "tracer bullet: hello world" },
+  { name: "ghafk.md", inputs: "" },
+  { name: "review.md", inputs: "" },
+];
+
+let failures = 0;
+const check = (name, cond, detail) => {
+  if (cond) process.stdout.write(`ok    ${name}\n`);
+  else {
+    process.stdout.write(`FAIL  ${name}${detail ? `\n      ${detail}` : ""}\n`);
+    failures++;
+  }
+};
+
+for (const { name, inputs } of cases) {
+  const work = mkdtempSync(
+    join(tmpdir(), `ralph-smoke-${name.replace(".md", "")}-`)
+  );
+  const spillRel = `spill-test-${name}`;
+  const spillHostDir = join(work, ".ralph-tmp", spillRel);
+  const spillRefPath = posix.join(".ralph-tmp", spillRel);
+  try {
+    const out = renderTemplate(
+      join(tplDir, name),
+      { INPUTS: inputs },
+      { cwd: repo, spillHostDir, spillRefPath }
+    );
+    const tokensApprox = Math.round(out.length / 4);
+    process.stdout.write(
+      `---- ${name} : ${out.length} chars (~${tokensApprox} tok)\n`
+    );
+    check(
+      `${name}: under 20k tokens`,
+      tokensApprox < 20000,
+      `~${tokensApprox} tok`
+    );
+
+    if (name === "ghafk.md") {
+      check(`${name}: has <issues-summary>`, out.includes("<issues-summary>"));
+      check(
+        `${name}: spill path inlined`,
+        out.includes(`./${spillRefPath}/issues.json`)
+      );
+      check(
+        `${name}: spill file exists`,
+        existsSync(join(spillHostDir, "issues.json"))
+      );
+    }
+    if (name === "review.md") {
+      check(
+        `${name}: spill path inlined`,
+        out.includes(`./${spillRefPath}/head.diff`)
+      );
+      check(
+        `${name}: spill file exists`,
+        existsSync(join(spillHostDir, "head.diff"))
+      );
+      check(`${name}: includes REVIEWER`, out.includes("# REVIEWER"));
+    }
+    if (name === "afk.md") {
+      check(
+        `${name}: INPUTS substituted`,
+        out.includes("tracer bullet: hello world")
+      );
+    }
+  } catch (e) {
+    check(`${name}: render did not throw`, false, String(e));
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+if (failures) {
+  process.stderr.write(`\n${failures} failure(s)\n`);
+  process.exit(1);
+}
+process.stdout.write("\nall pass\n");


### PR DESCRIPTION
Prevent oversized prompt payloads from breaching tool input limits by moving heavy rendered template content into temporary side files and reading from them at runtime.

Why:
- Large rendered templates can exceed tool/request size limits and fail runs.
- Keeping the main prompt lean while loading bulky sections from files avoids truncation/token-limit failures.

What changed:
- Update render/runner flow to support spilling large rendered sections to temporary files.
- Adjust loop/runner integration so stages can consume spilled content safely.
- Update templates to reference the new spill strategy where needed.
- Add smoke scripts to validate rendering and spill-size behavior:
  - scripts/smoke-render.mjs
  - scripts/smoke-spill-large.mjs
  - scripts/smoke-spill-size.mjs
  - scripts/smoke-templates.mjs

Files touched:
- packages/core/src/loop.ts
- packages/core/src/render.ts
- packages/core/src/runner.ts
- packages/core/templates/ghafk.md
- packages/core/templates/ghprompt.md
- packages/core/templates/review.md