### PR TITLE
feat(core): --version flag + docker socket config in --print-config

### DIFF
--- a/apps/cli/bin/ralph-afk.js
+++ b/apps/cli/bin/ralph-afk.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { runAfk } from "@daonhan/ralph-core";
 
-runAfk(process.argv.slice(2)).catch((e) => {
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = join(here, "..", "package.json");
+const cliVersion = JSON.parse(readFileSync(pkgPath, "utf8")).version;
+
+runAfk(process.argv.slice(2), { cliVersion }).catch((e) => {
   console.error(e?.stack ?? e);
   process.exit(1);
 });

--- a/apps/cli/bin/ralph-ghafk.js
+++ b/apps/cli/bin/ralph-ghafk.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { runGhAfk } from "@daonhan/ralph-core";
 
-runGhAfk(process.argv.slice(2)).catch((e) => {
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgPath = join(here, "..", "package.json");
+const cliVersion = JSON.parse(readFileSync(pkgPath, "utf8")).version;
+
+runGhAfk(process.argv.slice(2), { cliVersion }).catch((e) => {
   console.error(e?.stack ?? e);
   process.exit(1);
 });

--- a/packages/core/src/cli-help.ts
+++ b/packages/core/src/cli-help.ts
@@ -1,19 +1,58 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { IMAGE_REF, resolveDockerfile } from "./runner.js";
+import {
+  IMAGE_REF,
+  detectDockerSocketPath,
+  resolveDockerSocketMount,
+  resolveDockerfile,
+} from "./runner.js";
 
-export type CliFlags = { help: boolean; printConfig: boolean; rest: string[] };
+export type CliFlags = {
+  help: boolean;
+  version: boolean;
+  printConfig: boolean;
+  rest: string[];
+};
 
 export function parseFlags(argv: string[]): CliFlags {
   let help = false;
+  let version = false;
   let printConfig = false;
   const rest: string[] = [];
   for (const a of argv) {
     if (a === "-h" || a === "--help") help = true;
+    else if (a === "-V" || a === "--version") version = true;
     else if (a === "--print-config") printConfig = true;
     else rest.push(a);
   }
-  return { help, printConfig, rest };
+  return { help, version, printConfig, rest };
+}
+
+/**
+ * Resolve the @daonhan/ralph-core version by reading the package.json that
+ * sits two levels up from the compiled cli-help.js (packages/core/dist/ →
+ * packages/core/package.json). Returns "?" if unreadable so version reporting
+ * never crashes the bin.
+ */
+export function readCoreVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkgPath = join(here, "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+      version?: string;
+    };
+    return pkg.version ?? "?";
+  } catch {
+    return "?";
+  }
+}
+
+export function printVersion(bin: string, cliVersion?: string): void {
+  const core = readCoreVersion();
+  const cli = cliVersion ?? "?";
+  process.stdout.write(`${bin} ${cli} (core ${core})\n`);
 }
 
 export function printHelp(
@@ -26,11 +65,13 @@ export function printHelp(
 Usage:
   ${bin} ${usage}
   ${bin} --help | -h
+  ${bin} --version | -V
   ${bin} --print-config [args...]
 
 Flags:
   -h, --help          show this help and exit
-  --print-config      resolve workspace / docker context / image, print, exit without launching docker
+  -V, --version       print bin + core version and exit
+  --print-config      resolve workspace / docker context / image / docker socket, print, exit without launching docker
 
 Environment variables:
   RALPH_WORKSPACE       host dir bind-mounted at /home/agent/workspace (default: cwd)
@@ -59,15 +100,43 @@ export function printConfig(
   bin: string,
   workspaceDir: string,
   ralphDir: string,
-  sandcastleDir: string
+  sandcastleDir: string,
+  cliVersion?: string
 ): void {
   const dockerfile = resolveDockerfile(ralphDir);
   const dfPresent = existsSync(dockerfile);
+  const core = readCoreVersion();
+  const cli = cliVersion ?? "?";
+
+  const sockOptOut = process.env.RALPH_DOCKER_SOCK === "0";
+  const detectedSock = detectDockerSocketPath();
+  const sockSource = process.env.RALPH_DOCKER_SOCK_PATH
+    ? "RALPH_DOCKER_SOCK_PATH"
+    : process.env.DOCKER_HOST?.startsWith("unix://")
+      ? "DOCKER_HOST"
+      : "auto-detected";
+  const mountArgs = resolveDockerSocketMount();
+  const groupAdd =
+    mountArgs && mountArgs.includes("--group-add")
+      ? mountArgs[mountArgs.indexOf("--group-add") + 1]
+      : null;
+
+  let sockStatus: string;
+  if (sockOptOut) {
+    sockStatus = "disabled (RALPH_DOCKER_SOCK=0)";
+  } else if (!detectedSock) {
+    sockStatus = "no socket found";
+  } else {
+    sockStatus = `mounting ${detectedSock} (${sockSource})${groupAdd ? `, --group-add ${groupAdd}` : ""}`;
+  }
+
   process.stdout.write(`[${bin}] resolved config
+  version               ${bin} ${cli} (core ${core})
   RALPH_WORKSPACE       ${workspaceDir}${process.env.RALPH_WORKSPACE ? "" : "  (default: cwd)"}
   RALPH_DOCKER_CONTEXT  ${ralphDir}${process.env.RALPH_DOCKER_CONTEXT ? "" : "  (default: bundled core dir)"}
   RALPH_IMAGE           ${IMAGE_REF}${process.env.RALPH_IMAGE || process.env.RALPH_IMAGE_TAG ? "" : "  (default)"}
   Dockerfile at ctx     ${dfPresent ? "present" : "MISSING"} (${dockerfile})
   sandcastleDir         ${sandcastleDir}
+  RALPH_DOCKER_SOCK     ${sockStatus}
 `);
 }

--- a/packages/core/src/gh-main.ts
+++ b/packages/core/src/gh-main.ts
@@ -1,7 +1,12 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { parseFlags, printConfig, printHelp } from "./cli-help.js";
+import {
+  parseFlags,
+  printConfig,
+  printHelp,
+  printVersion,
+} from "./cli-help.js";
 import { runLoop } from "./loop.js";
 import { STAGES } from "./stages.js";
 
@@ -9,9 +14,18 @@ const BIN = "ralph-ghafk";
 const USAGE = "<iterations>";
 const DESC = "GitHub-issue-driven Claude Code AFK loop";
 
-export async function runGhAfk(argv: string[]): Promise<void> {
+export type RunGhAfkOptions = { cliVersion?: string };
+
+export async function runGhAfk(
+  argv: string[],
+  opts: RunGhAfkOptions = {}
+): Promise<void> {
   const flags = parseFlags(argv);
 
+  if (flags.version) {
+    printVersion(BIN, opts.cliVersion);
+    return;
+  }
   if (flags.help) {
     printHelp(BIN, USAGE, DESC);
     return;
@@ -23,7 +37,7 @@ export async function runGhAfk(argv: string[]): Promise<void> {
   const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
 
   if (flags.printConfig) {
-    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir);
+    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, opts.cliVersion);
     return;
   }
 

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,7 +1,12 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { parseFlags, printConfig, printHelp } from "./cli-help.js";
+import {
+  parseFlags,
+  printConfig,
+  printHelp,
+  printVersion,
+} from "./cli-help.js";
 import { runLoop } from "./loop.js";
 import { STAGES } from "./stages.js";
 
@@ -9,9 +14,18 @@ const BIN = "ralph-afk";
 const USAGE = "<plan-and-prd> <iterations>";
 const DESC = "plan/PRD-driven Claude Code AFK loop";
 
-export async function runAfk(argv: string[]): Promise<void> {
+export type RunAfkOptions = { cliVersion?: string };
+
+export async function runAfk(
+  argv: string[],
+  opts: RunAfkOptions = {}
+): Promise<void> {
   const flags = parseFlags(argv);
 
+  if (flags.version) {
+    printVersion(BIN, opts.cliVersion);
+    return;
+  }
   if (flags.help) {
     printHelp(BIN, USAGE, DESC);
     return;
@@ -23,7 +37,7 @@ export async function runAfk(argv: string[]): Promise<void> {
   const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
 
   if (flags.printConfig) {
-    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir);
+    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, opts.cliVersion);
     return;
   }
 


### PR DESCRIPTION
## Summary

- Add `-V` / `--version` to both `ralph-afk` and `ralph-ghafk`. Prints `bin X.Y.Z (core X.Y.Z)` and exits.
- Both bins now read their own `apps/cli/package.json` and thread the resolved version through a new `opts.cliVersion` arg on `runAfk` / `runGhAfk`. Core reads its own `packages/core/package.json` from `cli-help.ts` so the two version strings are independently resolved.
- `--print-config` now also shows:
  - cli + core version
  - docker socket resolution: detected path, source (`auto-detected`, `DOCKER_HOST`, or `RALPH_DOCKER_SOCK_PATH`), mount status (`enabled`, `disabled (RALPH_DOCKER_SOCK=0)`, or `no socket found`), and any `--group-add` value the runner will pass.
- `--help` text updated for the new flag and the expanded `--print-config` semantics.

Version override

`Release-As:` trailers on the commit pin both component releases to `0.5.1` rather than the default minor bump release-please would compute from `feat:`.

## Test plan

- [x] `pnpm -r typecheck` + `pnpm -r build` clean
- [x] `ralph-afk --version` → `ralph-afk 0.5.0 (core 0.5.0)` (will read 0.5.1 once published)
- [x] `ralph-ghafk -V` → same shape, different bin name
- [x] `ralph-afk --print-config` shows `version` line and `RALPH_DOCKER_SOCK mounting /var/run/docker.sock (auto-detected), --group-add 0`
- [x] `RALPH_DOCKER_SOCK=0 ralph-afk --print-config` shows `disabled (RALPH_DOCKER_SOCK=0)`
- [x] `RALPH_DOCKER_SOCK_PATH=/run/user/1000/docker.sock ralph-afk --print-config` shows `mounting /run/user/1000/docker.sock (RALPH_DOCKER_SOCK_PATH), --group-add 0`
- [x] `ralph-afk --help` lists `-V, --version` and the updated `--print-config` description
- [ ] Post-merge: confirm `npm i -g @daonhan/ralph@0.5.1 && ralph-afk --version` prints `0.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)