### PR TITLE
Keep Ralph alive while AFK

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.tsbuildinfo
 .ralph-tmp/
 .ghafk-prompt-*.md
+.pnpm-store/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. See [.claude/CLAUDE.md](.claude/CLAUDE.md) (behavioral rules).
 
 ## What this repo is
 
@@ -121,3 +121,7 @@ Every run writes to `<workspaceDir>/.ralph-tmp/` on the host (gitignored): the r
 - `docs/PUBLISHING.md` — npm publish notes.
 - `packages/core/templates/prompt.md` / `ghprompt.md` — agent playbooks. Edit these to change feedback loops or task priority.
 - `packages/core/templates/{afk,ghafk,review}.md` — iteration templates that `@include` the playbooks above.
+
+## Behavioral
+
+Apply `.claude/CLAUDE.md` (think first, simplicity, surgical changes, goal-driven). Make only changes the user asked for; match existing style; prefer smallest correct change; push back on over-engineering; state a brief plan + success criteria for non-trivial work.

--- a/README.md
+++ b/README.md
@@ -297,6 +297,34 @@ No plan/PRD arg — context comes from open GitHub issues.
 
 ---
 
+## Running AFK
+
+Both bins are designed to chew through long runs unattended. Five AFK flags wire that up:
+
+| Flag                | Default                                          | What it does                                                             |
+| ------------------- | ------------------------------------------------ | ------------------------------------------------------------------------ |
+| `--no-keep-alive`   | off (wake-lock acquired)                         | Skip the OS wake-lock for the loop's lifetime.                           |
+| `--max-retries <N>` | `3`                                              | Per-stage retry budget on transient failures. `0` restores fail-fast.    |
+| `--detach`          | off                                              | Fork the loop into a background process, print pid + log path, and exit. |
+| `--log <path>`      | `<workspace>/.ralph-tmp/logs/detached-<pid>.log` | Override the detached log target. Only meaningful with `--detach`.       |
+| `--notify`          | off                                              | OS toast + terminal bell on loop completion or unrecoverable failure.    |
+
+Canonical overnight recipe:
+
+```bash
+ralph-afk --detach --notify "<plan-and-prd>" 50
+```
+
+This forks into the background, holds an OS wake-lock so the host doesn't sleep, retries transient stage failures up to 3× with exponential backoff (`5s / 30s / 2m`), and raises a toast + bell when the run finishes (sentinel hit or iteration cap reached) or fails (signal, uncaught exception). Tail the log from any shell:
+
+```bash
+tail -f <workspace>/.ralph-tmp/logs/detached-*.log
+```
+
+Full per-OS notes (wake-lock mechanism, BurntToast install, WSL2 caveat, etc.) live in [`docs/keep-alive.md`](./docs/keep-alive.md).
+
+---
+
 ## Consuming the package in another repo
 
 ### Global install (recommended — run from anywhere)

--- a/README.md
+++ b/README.md
@@ -301,13 +301,13 @@ No plan/PRD arg — context comes from open GitHub issues.
 
 Both bins are designed to chew through long runs unattended. Five AFK flags wire that up:
 
-| Flag                | Default                                          | What it does                                                             |
-| ------------------- | ------------------------------------------------ | ------------------------------------------------------------------------ |
-| `--no-keep-alive`   | off (wake-lock acquired)                         | Skip the OS wake-lock for the loop's lifetime.                           |
-| `--max-retries <N>` | `3`                                              | Per-stage retry budget on transient failures. `0` restores fail-fast.    |
-| `--detach`          | off                                              | Fork the loop into a background process, print pid + log path, and exit. |
-| `--log <path>`      | `<workspace>/.ralph-tmp/logs/detached-<pid>.log` | Override the detached log target. Only meaningful with `--detach`.       |
-| `--notify`          | off                                              | OS toast + terminal bell on loop completion or unrecoverable failure.    |
+| Flag                | Default                                                 | What it does                                                             |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `--no-keep-alive`   | off (wake-lock acquired)                                | Skip the OS wake-lock for the loop's lifetime.                           |
+| `--max-retries <N>` | `3`                                                     | Per-stage retry budget on transient failures. `0` restores fail-fast.    |
+| `--detach`          | off                                                     | Fork the loop into a background process, print pid + log path, and exit. |
+| `--log <path>`      | `<workspace>/.ralph-tmp/logs/detached-<parent-pid>.log` | Override the detached log target. Only meaningful with `--detach`.       |
+| `--notify`          | off                                                     | OS toast + terminal bell on loop completion or unrecoverable failure.    |
 
 Canonical overnight recipe:
 

--- a/docs/keep-alive.md
+++ b/docs/keep-alive.md
@@ -1,0 +1,96 @@
+# Keep Ralph Alive While AFK
+
+Ralph's `ralph-afk` / `ralph-ghafk` bins acquire an OS wake-lock for the lifetime of the loop so a sleeping laptop doesn't kill an overnight run. This is on by default — no flag, no manual OS recipe.
+
+## What's automatic (Phase 1)
+
+| OS      | Mechanism                                                                                            | Scope                                                                                        |
+| ------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Windows | long-lived `powershell` child calling `SetThreadExecutionState(ES_CONTINUOUS \| ES_SYSTEM_REQUIRED)` | system sleep only — display can still dim                                                    |
+| macOS   | `caffeinate -i -w <pid>`                                                                             | system sleep only; ties caffeinate's lifetime to the parent pid so a SIGKILL still cleans up |
+| Linux   | `systemd-inhibit --what=sleep --mode=block sleep infinity`                                           | system sleep only                                                                            |
+| WSL2    | Linux path runs (blocks WSL idle), **plus** a warning that it does not block Windows host sleep      | see caveat below                                                                             |
+
+The wake-lock is acquired before iteration 1 and released on any exit path:
+
+- clean completion (sentinel hit or iteration cap reached)
+- thrown exception in any stage
+- `SIGINT` (Ctrl-C) — process exits 130 after release
+- `SIGTERM` — process exits 143 after release
+
+## Opt out
+
+Pass `--no-keep-alive` to skip wake-lock acquisition entirely. Useful for short interactive runs where Ctrl-C should be instant.
+
+```bash
+ralph-afk --no-keep-alive "<plan>" 3
+```
+
+`--print-config` shows the current state:
+
+```
+keep-alive            on (system sleep only)
+```
+
+or:
+
+```
+keep-alive            off
+```
+
+## Per-OS notes
+
+### Windows
+
+No admin required. `SetThreadExecutionState` is a user-level Win32 API; the wake-lock holds for the lifetime of the `powershell` child, which is killed when the loop releases. Verify with:
+
+```powershell
+powercfg /requests
+```
+
+You should see a `SYSTEM` request while the loop is running, and no requests after it exits.
+
+### macOS
+
+`caffeinate -i` blocks idle system sleep but allows the display to dim/sleep — that's intentional so a battery laptop doesn't burn through the night with the screen on. Verify with:
+
+```bash
+pmset -g assertions | grep PreventUserIdleSystemSleep
+```
+
+The `-w <pid>` flag makes caffeinate self-terminate if the parent dies first, so a `kill -9` on `ralph-afk` still releases the inhibitor.
+
+### Linux
+
+Requires `systemd-inhibit` (ships with systemd). Verify with:
+
+```bash
+systemd-inhibit --list
+```
+
+If `systemd-inhibit` is missing (minimal container, chroot, etc.), the loop logs one warning to stderr and continues without the wake-lock — it never crashes on a missing utility.
+
+### WSL2
+
+WSL2 is detected by sniffing `/proc/version` for `microsoft`. The Linux path still runs (and blocks WSL idle if systemd is enabled in `/etc/wsl.conf`), but **it cannot block Windows host sleep**. A one-line warning is emitted at acquisition.
+
+If you're running overnight AFK loops from WSL2, configure the Windows power plan separately:
+
+```powershell
+powercfg /change standby-timeout-ac 0
+powercfg /change standby-timeout-dc 0
+```
+
+A WSL2 → Windows host wake-lock bridge would require a Windows-side helper process; that's out of scope for v1.
+
+## Coming in later phases
+
+- **Phase 2** — per-iteration retry with exponential backoff (`--max-retries`).
+- **Phase 3** — `--detach` fork-and-exit so closing the terminal doesn't kill the loop (`--log <path>` to override the log target).
+- **Phase 4** — `--notify` for OS-native notifications + terminal bell on terminal events.
+
+## Out of scope (v1)
+
+- **Power-loss / battery-death** — a dead battery kills the loop. Use a UPS if you care about overnight resilience to power events.
+- **Resume on restart** — if the host reboots, the loop does not auto-resume from iteration N+1. The git commits the loop has already produced are the practical resume mechanism.
+- **WSL2 → Windows host wake-lock bridge** — see WSL2 section above. Run natively on Windows for AFK use, or set the Windows power plan manually.

--- a/docs/keep-alive.md
+++ b/docs/keep-alive.md
@@ -161,12 +161,69 @@ or with `--detach` active:
 detach                on (log: /path/to/workspace/.ralph-tmp/logs/detached-12300.log)
 ```
 
-## Coming in later phases
+## Notify (Phase 4)
 
-- **Phase 4** — `--notify` for OS-native notifications + terminal bell on terminal events.
+`--notify` opts into a best-effort OS notification + terminal bell on every terminal event:
+
+- **Clean completion** — sentinel hit or iteration cap reached → `info`-level notification.
+- **Unrecoverable failure** — uncaught exception, `SIGINT` (Ctrl-C), or `SIGTERM` during a run → `error`-level notification.
+
+Calls are fire-and-forget: the loop never blocks on toast delivery, and a missing OS utility never crashes. A terminal bell (`\x07`) is written to stderr on every notification regardless of OS path, so even a headless terminal with no toast surface still gets an audible signal.
+
+| OS      | Mechanism                                                                      | Fallback                                  |
+| ------- | ------------------------------------------------------------------------------ | ----------------------------------------- |
+| Windows | `powershell` → `New-BurntToastNotification` (if BurntToast installed)          | `msg.exe * "<title>: <body>"` → bell-only |
+| macOS   | `osascript -e 'display notification … sound name "Glass"'` (`Basso` for error) | bell-only                                 |
+| Linux   | `notify-send --urgency normal` (or `critical` for error)                       | bell-only                                 |
+
+```bash
+ralph-afk --notify "<plan>" 50
+```
+
+### Windows: BurntToast (optional)
+
+For real Windows 10/11 toasts install the BurntToast PowerShell module once:
+
+```powershell
+Install-Module -Name BurntToast -Force
+```
+
+Without it, the bin falls through to `msg.exe` (a console message dialog), and then to bell-only if `msg.exe` is missing too (Windows Home does not ship it).
+
+### macOS
+
+No setup needed — `osascript` is built in. Notifications appear in the Notification Center; the sound name is `Glass` for `info` and `Basso` for `error`.
+
+### Linux
+
+Requires `libnotify` (`notify-send`). Most desktop distros ship it; on headless servers install `libnotify-bin` (Debian/Ubuntu) or rely on the bell.
+
+`--print-config` shows the current state:
+
+```
+notify                on
+```
+
+or:
+
+```
+notify                off
+```
 
 ## Out of scope (v1)
 
 - **Power-loss / battery-death** — a dead battery kills the loop. Use a UPS if you care about overnight resilience to power events.
 - **Resume on restart** — if the host reboots, the loop does not auto-resume from iteration N+1. The git commits the loop has already produced are the practical resume mechanism.
 - **WSL2 → Windows host wake-lock bridge** — see WSL2 section above. Run natively on Windows for AFK use, or set the Windows power plan manually.
+- **Notification rich-actions / grouping** — plain title + body + bell only. No clickable actions, no Notification Center categorization, no mid-loop progress toasts.
+
+## Canonical overnight recipe
+
+```bash
+ralph-afk --detach --notify "<plan-and-prd>" 50
+```
+
+- `--detach` forks the loop into the background so you can close the terminal.
+- `--notify` raises an OS toast + bell when the run finishes (or fails).
+- Wake-lock and 3× retry are on by default — no flags needed.
+- Default log: `<workspace>/.ralph-tmp/logs/detached-<pid>.log` (override with `--log`).

--- a/docs/keep-alive.md
+++ b/docs/keep-alive.md
@@ -83,9 +83,40 @@ powercfg /change standby-timeout-dc 0
 
 A WSL2 → Windows host wake-lock bridge would require a Windows-side helper process; that's out of scope for v1.
 
+## Per-stage retry (Phase 2)
+
+Every `runStage` call is wrapped in an exponential-backoff retry. A transient failure (network blip, claude API hiccup, a brief docker daemon stall) no longer aborts the loop.
+
+Defaults:
+
+| Setting     | Value         |
+| ----------- | ------------- |
+| Max retries | `3`           |
+| Backoff     | `5s, 30s, 2m` |
+
+After the retry budget is exhausted, the failing stage is **skipped** — the loop moves on to the next iteration instead of throwing out of `runLoop`. A persistent gate-stage failure simply means no sentinel was seen, so the loop keeps iterating until it hits the iteration cap.
+
+Each retry is announced both on stderr and as a one-line marker appended to the per-stage NDJSON log:
+
+```
+[retry] attempt 1 of 3 after 5000 ms
+```
+
+Override via `--max-retries <N>` on either bin. `--max-retries 0` restores the previous fail-fast behavior (a single attempt; any failure breaks out of the current iteration's stage chain).
+
+```bash
+ralph-afk --max-retries 5 "<plan>" 50    # dial up for flaky environments
+ralph-afk --max-retries 0 "<plan>" 1     # fail fast on a short interactive run
+```
+
+`--print-config` shows the current value:
+
+```
+max-retries           3
+```
+
 ## Coming in later phases
 
-- **Phase 2** — per-iteration retry with exponential backoff (`--max-retries`).
 - **Phase 3** — `--detach` fork-and-exit so closing the terminal doesn't kill the loop (`--log <path>` to override the log target).
 - **Phase 4** — `--notify` for OS-native notifications + terminal bell on terminal events.
 

--- a/docs/keep-alive.md
+++ b/docs/keep-alive.md
@@ -115,9 +115,54 @@ ralph-afk --max-retries 0 "<plan>" 1     # fail fast on a short interactive run
 max-retries           3
 ```
 
+## Detach (Phase 3)
+
+`--detach` forks the loop into the background and exits the parent immediately with code `0`. Closing the terminal, dropping SSH, or logging out of the desktop session no longer kills the loop — the child is reparented to init and keeps iterating.
+
+```bash
+ralph-afk --detach "<plan>" 50
+# detached pid 12345, log /path/to/workspace/.ralph-tmp/logs/detached-12300.log
+```
+
+Under the hood:
+
+- The bin re-spawns itself via `process.execPath` (the same node binary) with `--detach` and `--log` stripped from argv. The child cannot fork again — no infinite loop.
+- Child stdio (stdout + stderr) is appended to the log file. Multiple runs targeting the same path concatenate cleanly rather than truncating.
+- The spawn is `detached: true` + `unref()` so the parent can exit. On Windows, `windowsHide: true` keeps a console window from popping in PowerShell.
+- The wake-lock + retry behavior from Phase 1 / Phase 2 still apply — they're acquired in the child, not orphaned in the parent.
+
+### Log target
+
+Default: `<workspace>/.ralph-tmp/logs/detached-<pid>.log` (the `<pid>` is the original parent process, fixed at fork time). Override with `--log <path>`:
+
+```bash
+ralph-afk --detach --log /var/log/ralph-overnight.log "<plan>" 50
+```
+
+`--log` without `--detach` is rejected (it is only meaningful in detached mode).
+
+### Reattaching
+
+There is no reattach surface in v1. Tail the log from any shell:
+
+```bash
+tail -f /path/to/workspace/.ralph-tmp/logs/detached-12300.log
+```
+
+`--print-config` shows the current state:
+
+```
+detach                off
+```
+
+or with `--detach` active:
+
+```
+detach                on (log: /path/to/workspace/.ralph-tmp/logs/detached-12300.log)
+```
+
 ## Coming in later phases
 
-- **Phase 3** — `--detach` fork-and-exit so closing the terminal doesn't kill the loop (`--log <path>` to override the log target).
 - **Phase 4** — `--notify` for OS-native notifications + terminal bell on terminal events.
 
 ## Out of scope (v1)

--- a/docs/plans/keep-alive.md
+++ b/docs/plans/keep-alive.md
@@ -1,0 +1,132 @@
+# Plan: Keep Ralph Alive While AFK
+
+> Source PRD: [docs/prd/keep-alive.md](../prd/keep-alive.md) · GitHub issue [#17](https://github.com/daonhan/ralph/issues/17)
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **New deep modules** (live in `packages/core/src/`):
+  - `keepalive` — cross-OS wake-lock dispatcher with injected spawner
+  - `retry` — pure backoff scheduler with `onAttempt` hook
+  - `detach` — fork-and-exit driver around `process.execPath`
+  - `notify` — OS toast + bell dispatcher with graceful fallback chain
+- **Module depth contract** — `loop.ts`, `main.ts`, `gh-main.ts` stay shallow glue. All cross-platform branching lives in the deep modules; `loop.ts` only orchestrates.
+- **Flag surface** (additive on both `ralph-afk` and `ralph-ghafk`):
+  - `--no-keep-alive` — opt out of wake-lock
+  - `--max-retries <N>` — per-iteration retry budget, default `3`
+  - `--detach` — fork to background and exit
+  - `--log <path>` — override detach log path
+  - `--notify` — emit OS notifications + bell on terminal events
+- **Wake-lock scope** — system sleep only (not display sleep). Matches `caffeinate -i` / `ES_SYSTEM_REQUIRED` / `systemd-inhibit --what=sleep`.
+- **Retry defaults** — 3 attempts with backoff `[5_000, 30_000, 120_000]` ms. `--max-retries 0` restores current fail-fast behavior. Persistent failure skips the iteration (does not abort the whole loop).
+- **Detach log default** — `.ralph-tmp/logs/detached-<pid>.log` (co-located with existing NDJSON logs).
+- **Signal contract** — `SIGINT` → exit 130, `SIGTERM` → exit 143. Both release the wake-lock and kill any in-flight docker child via a single `finally` + `process.on("exit", …)` pair.
+- **Test framework** — `vitest` added to `packages/core` devDependencies with a `test` script. Not shipped in the npm tarball (`files` array unchanged).
+- **WSL2 detection** — sniff `/proc/version` for `microsoft`; emit a one-line warning that the Linux path only blocks WSL idle, not Windows host sleep.
+- **Graceful degradation** — when an OS utility is missing (no `caffeinate`, no `notify-send`, no `BurntToast`), emit a stderr warning and return a no-op. Never crash the loop on a missing convenience.
+- **Progressive `--print-config`** — each phase adds its own line to the existing diagnostic output (`keep-alive`, `max-retries`, `detach`, etc.). Final surface is documented in the PRD.
+
+---
+
+## Phase 1: Wake-lock default-on + signal handling
+
+**User stories**: 1, 2, 3, 4, 5, 6, 7, 20, 23, 25 (partial), 26 (partial)
+
+### What to build
+
+A `keepalive` deep module that acquires an OS wake-lock on entry to `runLoop` and releases it on any exit path (clean return, thrown exception, `SIGINT`, `SIGTERM`). Windows uses a long-lived `powershell` child calling `SetThreadExecutionState`; macOS uses `caffeinate -i -w <pid>`; Linux uses `systemd-inhibit --what=sleep … sleep infinity`; WSL2 is detected and warned about. Missing utility paths emit a warning and degrade to a no-op releaser. Signal handlers installed by the loop release the lock and exit with the conventional non-zero code. `--no-keep-alive` opts out entirely. The `--print-config` diagnostic gains a `keep-alive` line. `vitest` is added to `packages/core` and the `keepalive` tests cover all four platform branches plus the no-op fallback. The `docs/keep-alive.md` doc is rewritten for the wake-lock half (the retry / detach / notify sections are placeholders updated in later phases).
+
+### Acceptance criteria
+
+- [ ] `keepalive` module exposes `acquire({ reason?, spawner? }): { release(): void }`.
+- [ ] Windows / macOS / Linux / WSL2 platform branches each pass the documented argv to the injected spawner.
+- [ ] Unit tests verify per-OS argv and that `release()` kills the child for each branch.
+- [ ] Missing-utility path (spawner throws `ENOENT`) emits one warning to stderr and returns a no-op releaser whose `release()` is safe to call.
+- [ ] `vitest` is wired into `packages/core` (`devDependencies`, `test` script). `pnpm --filter @daonhan/ralph-core test` runs the suite green.
+- [ ] `loop.ts` acquires the lock before iteration 1 and releases it in a `finally` that also covers `SIGINT` / `SIGTERM`.
+- [ ] `SIGINT` exits with code `130`; `SIGTERM` exits with code `143`. Wake-lock child is dead after either signal.
+- [ ] `--no-keep-alive` flag on both bins skips acquisition entirely (verified via `--print-config` showing `keep-alive : off`).
+- [ ] `--print-config` shows `keep-alive : on (system sleep only)` by default and `keep-alive : off` when opted out.
+- [ ] Help text (`--help`) documents `--no-keep-alive`.
+- [ ] Windows smoke: a short `ralph-afk` run holds a `SYSTEM` request visible in `powercfg /requests`, released on exit.
+- [ ] macOS smoke: `pmset -g assertions` shows `PreventUserIdleSystemSleep` during the run, released on exit.
+- [ ] Linux smoke: `systemd-inhibit --list` shows the inhibitor during the run, released on exit.
+- [ ] WSL2 smoke: a warning is emitted, the loop continues, and the inhibitor (if systemd is present) appears.
+- [ ] `docs/keep-alive.md` rewritten to describe the new built-in wake-lock behavior, WSL2 caveat, and `--no-keep-alive` escape hatch.
+
+---
+
+## Phase 2: Per-iteration retry default-on
+
+**User stories**: 8, 9, 10, 11, 21 (partial), 22 (partial), 25 (partial)
+
+### What to build
+
+A `retry` deep module providing `withRetries(fn, { max, backoffMs, onAttempt })` that invokes `fn` up to `max + 1` times with the documented exponential backoff and an `onAttempt(n, err)` hook fired before each retry. The loop wraps every `runStage` call in `withRetries` so transient failures inside a single iteration do not abort the loop. A persistent failure after the retry budget is exhausted is logged (both to stderr and to the NDJSON log as a `[retry] attempt N of M after Ms ms` marker) and the loop proceeds to the next iteration. The `--max-retries <N>` flag overrides the default (`0` restores current fail-fast behavior). The `--print-config` diagnostic gains a `max-retries` line.
+
+### Acceptance criteria
+
+- [ ] `retry` module exposes `withRetries<T>(fn, opts): Promise<T>` with the documented backoff and `onAttempt` semantics.
+- [ ] Unit tests cover: first-attempt success (no delay), success on the third attempt with observed `[5s, 30s]` waits, persistent failure with `max: 3` (four total calls, `[5s, 30s, 2m]` waits, last error rethrown), `max: 0` (single call, immediate rethrow), and `onAttempt` invocation order.
+- [ ] Unit tests use fake timers — no real wall-clock waits.
+- [ ] `loop.ts` wraps each `runStage` invocation in `withRetries` with the user's retry budget.
+- [ ] Persistent iteration failure is logged and the loop continues to the next iteration (does not throw out of `runLoop`).
+- [ ] Each retry attempt appends a `[retry] attempt N of M after Ms ms` marker line to the per-iteration NDJSON log.
+- [ ] `--max-retries <N>` validates `N >= 0` and rejects non-integer inputs with a clear error.
+- [ ] `--print-config` shows `max-retries : 3` by default and the user's value when overridden.
+- [ ] Help text documents `--max-retries`.
+- [ ] Smoke: a deliberately-failing iteration (e.g. a plan whose first stage exits non-zero) triggers exactly the configured number of retries, then the loop continues to the next iteration and reports clean exit.
+
+---
+
+## Phase 3: `--detach` fork-and-exit
+
+**User stories**: 12, 13, 14, 15, 25 (partial)
+
+### What to build
+
+A `detach` module that re-spawns the current bin with `--detach` stripped from argv, stdio redirected to a log file, `detached: true`, and `windowsHide: true`. The parent prints `detached pid <pid>, log <path>` and exits cleanly. `main.ts` and `gh-main.ts` call `detachAndExit` before any other side effect so the wake-lock is acquired in the child (not orphaned in the parent). `--log <path>` overrides the default log path. The `--print-config` diagnostic gains a `detach` line.
+
+### Acceptance criteria
+
+- [ ] `detach` module exposes `detachAndExit({ logPath, argv, binEntry }): never`.
+- [ ] Re-spawned child receives the original argv minus `--detach` (no infinite fork loop possible).
+- [ ] Detached child stdio (stdout + stderr) is redirected to `logPath`; the log file is created with append semantics so concurrent runs do not clobber each other.
+- [ ] Windows path passes `windowsHide: true` — no console window pops on PowerShell.
+- [ ] Parent prints `detached pid <pid>, log <path>` on stderr and exits with code `0`.
+- [ ] `--detach` is wired on both `ralph-afk` and `ralph-ghafk`. The wake-lock + retry behavior from Phases 1 and 2 still applies in the detached child.
+- [ ] `--log <path>` is honored when present; default is `.ralph-tmp/logs/detached-<pid>.log` when absent.
+- [ ] `--log` without `--detach` is rejected (or warned about) — the flag is only meaningful in detached mode.
+- [ ] `--print-config` shows `detach : off` by default and `detach : on (log: <path>)` when active.
+- [ ] Help text documents `--detach` and `--log`.
+- [ ] Smoke: `ralph-afk --detach "<plan>" 3` returns the prompt immediately; closing the parent terminal does not kill the loop; `tail -f` on the log path from a fresh shell shows iteration progress.
+
+---
+
+## Phase 4: `--notify` + finalize docs
+
+**User stories**: 16, 17, 18, 19, 24, 25 (rest), 26 (rest), 27
+
+### What to build
+
+A `notify` module that fires fire-and-forget OS notifications plus a terminal bell on loop completion (sentinel or iteration cap) and on unrecoverable failure (signal received, uncaught exception). Platform dispatch tries `BurntToast` → `msg.exe` → bell-only on Windows; `osascript display notification` on macOS; `notify-send` on Linux. All fallbacks degrade silently to bell-only. The loop is wired to call `notify({ level })` on terminal events. `--help` text gets a full overhaul covering every flag added in Phases 1–4. The `README.md` gains a "Running AFK" section showing the canonical overnight-run recipe. The `docs/keep-alive.md` rewrite is finalized (all sections populated, WSL2 limitation documented as out-of-scope, UPS recommendation noted).
+
+### Acceptance criteria
+
+- [ ] `notify` module exposes `notify({ title, body, sound?, level })` with `level` ∈ `"info" | "error"`.
+- [ ] Windows path tries `BurntToast`, then `msg.exe`, then bell-only. Missing modules / utilities never crash the call.
+- [ ] macOS path invokes `osascript -e 'display notification …'` with the documented `sound name "Glass"` for `info` and a different sound (or none) for `error`.
+- [ ] Linux path invokes `notify-send` with appropriate urgency for `info` vs `error`.
+- [ ] Bell (`\x07`) is written to stderr on every notification regardless of OS path.
+- [ ] Notification calls are fire-and-forget — `notify` returns synchronously; loop never waits on toast delivery.
+- [ ] Loop calls `notify({ level: "info" })` on clean completion (sentinel or iteration cap) when `--notify` is set.
+- [ ] Loop calls `notify({ level: "error" })` on unrecoverable failure (uncaught exception, `SIGINT` / `SIGTERM` during iteration) when `--notify` is set.
+- [ ] `--notify` flag is wired on both bins.
+- [ ] `--help` text on both bins lists all five new flags (`--no-keep-alive`, `--max-retries`, `--detach`, `--log`, `--notify`) with one-line descriptions.
+- [ ] `README.md` has a "Running AFK" section linking to `docs/keep-alive.md` and showing the canonical overnight-run recipe (e.g. `ralph-afk --detach --notify "<plan>" 50`).
+- [ ] `docs/keep-alive.md` is finalized: all sections populated (wake-lock, retry, detach, notify), WSL2 → Windows host limitation called out, power-loss / UPS recommendation noted as out-of-scope for v1.
+- [ ] Windows smoke: a 3-iteration run with `--notify` produces a toast on completion (or a bell-only fallback if neither BurntToast nor `msg.exe` is available).
+- [ ] macOS smoke: a 3-iteration run with `--notify` produces a banner notification on completion.
+- [ ] Linux smoke: a 3-iteration run with `--notify` produces a `notify-send` notification on completion.
+- [ ] Crash smoke: a deliberately-failing run with `--notify` produces an `error`-level notification.

--- a/docs/prd/keep-alive.md
+++ b/docs/prd/keep-alive.md
@@ -1,0 +1,234 @@
+# PRD: Keep Ralph Alive While AFK
+
+## Problem Statement
+
+As a Ralph user, I kick off `ralph-afk "<plan-and-prd>" 50` (or `ralph-ghafk 50`) before going to bed or stepping out, expecting the loop to chew through iterations overnight. In practice the loop dies in three different ways while I'm away:
+
+1. **My laptop goes to sleep.** Windows' default power profile suspends after 15–30 minutes of idle. macOS does the same. The docker container is killed when the host suspends; the next iteration never starts. I come back to a loop that ran 2 iterations out of 50.
+2. **My terminal disappears.** I close the laptop lid, an RDP session drops, an SSH connection times out, or I close the Windows Terminal window by mistake. The foreground node process dies with its parent shell and the loop ends mid-iteration.
+3. **A single iteration crashes the whole loop.** A network blip during `docker pull`, a transient claude CLI error, an OOM in a tool call — any one of these throws out of `runStage` and aborts the loop. Iterations 1–17 succeeded; iteration 18 hit a 500 from the API; the remaining 32 iterations never run.
+
+The repo today already names the bins `ralph-afk` / `ralph-ghafk`, but they only do the "iterate" half of AFK. Nothing in the harness keeps the host awake, keeps the process alive across a logoff, or recovers from a single bad iteration. Existing docs (`docs/keep-alive.md`) acknowledge the problem and copy nightshift's punt: tell the user to install `caffeinate` / `tmux` / change Windows power settings manually. That's three OS-specific recipes the user must remember and apply correctly every single time.
+
+I want to type `ralph-afk "<plan>" 50` and trust that it will still be running tomorrow morning — on Windows, on macOS, on Linux, on WSL2.
+
+## Solution
+
+`ralph-afk` and `ralph-ghafk` become true AFK tools: they acquire an OS wake-lock for their lifetime, retry transient iteration failures automatically, and expose opt-in `--detach` and `--notify` flags for users who want to log out of their terminal session entirely.
+
+From the user's perspective:
+
+- **Just running the bin keeps the host awake.** Wake-lock acquired before iteration 1, released on clean exit or signal. No flag required, no manual recipe per OS. Released even if the loop crashes.
+- **Iteration failures are retried automatically** with exponential backoff (5s / 30s / 2m). A persistent failure after three attempts gets logged and the loop moves on to the next iteration rather than aborting the whole run. Configurable via `--max-retries`.
+- **`ralph-afk --detach "<plan>" 50`** forks the loop into a background process, prints `PID + log path`, and returns the prompt immediately. The user can close their terminal, log off, or disconnect SSH without killing the loop. They reattach by tailing the log.
+- **`ralph-afk --notify "<plan>" 50`** raises an OS-native notification (Windows toast / macOS banner / Linux `notify-send`) on completion or unrecoverable failure, plus a terminal bell. Bell works in all terminals; toasts degrade gracefully where the OS facility is missing.
+- **Defaults are sensible for the bin's name.** Wake-lock and retry are on by default — the bin is literally called `afk`. Detach and notify stay opt-in because they change UX flow (no foreground output, modal toast). `--no-keep-alive` opts out of the wake-lock for short interactive runs.
+- **Per-OS notes live in `docs/keep-alive.md`**, kept honest with the actual implementation rather than copied from another project.
+
+## User Stories
+
+1. As a Ralph user, I want to run `ralph-afk "<plan>" 50` before bed and find the loop still running in the morning, so that I'm not wasting an overnight slot because Windows suspended at 23:30.
+2. As a Ralph user on Windows 11, I want the wake-lock to use `SetThreadExecutionState` (no admin required, no policy changes), so that I don't have to grant elevated privileges to a CLI.
+3. As a Ralph user on macOS, I want the wake-lock to be a `caffeinate -i -w <pid>` child that dies with the parent, so that crashed runs don't leak a permanent caffeine hold.
+4. As a Ralph user on Linux, I want the wake-lock to use `systemd-inhibit --what=sleep --mode=block sleep infinity`, so that the OS sleep gate is held exactly for the loop's lifetime.
+5. As a Ralph user on WSL2, I want the Linux `systemd-inhibit` path to also work (or at least degrade with a clear "WSL2 cannot block host sleep — set Windows power plan manually" warning), so that I'm not silently exposed to Windows host suspension.
+6. As a Ralph user, I want `--no-keep-alive` to skip the wake-lock entirely, so that short interactive runs don't leave a child process hanging around when I Ctrl-C.
+7. As a Ralph user on a machine without the relevant OS utility (e.g. `caffeinate` missing on a stripped Linux image), I want a warning rather than a hard crash, so that the loop still runs even if it might be suspended.
+8. As a Ralph user, I want a single iteration failure to retry up to 3 times with exponential backoff (5s / 30s / 2m), so that transient network blips and claude API hiccups don't kill the whole overnight run.
+9. As a Ralph user, I want retry attempts logged into the existing NDJSON stream as a `[retry] attempt N of 3 after Ms ms` event, so that I can audit failures the morning after.
+10. As a Ralph user, I want a persistently-failing iteration (after 3 retries) to be skipped, not abort the whole loop, so that one bad task doesn't lose me the remaining 30 iterations of useful work.
+11. As a Ralph user, I want `--max-retries <N>` to override the default, so that I can dial retries up for known-flaky environments or down to 0 to fail fast.
+12. As a Ralph user, I want `ralph-afk --detach "<plan>" 50` to fork into the background, print PID + log path, and exit immediately, so that I can close the terminal without killing the loop.
+13. As a Ralph user, I want the detached process to write all stdout + stderr to a log file at `.ralph-tmp/logs/detached-<pid>.log`, so that I can `tail -f` it from a fresh shell.
+14. As a Ralph user, I want `--log <path>` to override the default detach log location, so that I can pipe long-running output to a known place (e.g. on a separate disk).
+15. As a Ralph user on Windows, I want `--detach` to use `windowsHide: true` so the background process doesn't pop a console window, so that detaching looks clean in PowerShell.
+16. As a Ralph user, I want `--notify` to raise an OS-native notification on loop completion (sentinel hit or iteration cap reached), so that I notice the result without having to keep glancing at the terminal.
+17. As a Ralph user, I want `--notify` to raise an OS-native notification on unrecoverable loop failure (e.g. all retries exhausted on a critical step, docker daemon down), so that I don't waste hours assuming progress is being made.
+18. As a Ralph user, I want a terminal bell (`\x07`) on every notification event, so that even in environments without OS toast support I still get an audible signal.
+19. As a Ralph user, I want notifications to degrade gracefully (toast → bell-only → silent log line) without crashing the loop, so that the absence of `notify-send` or BurntToast doesn't break my run.
+20. As a Ralph user on a battery laptop, I want the wake-lock to block **system sleep only**, not display sleep, so that the screen can dim and turn off normally and I don't burn the battery overnight.
+21. As a Ralph maintainer, I want all wake-lock, retry, and detach logic in deep modules that can be unit-tested without spawning docker, so that I can verify cross-platform branching without setting up three CI hosts.
+22. As a Ralph maintainer, I want the `loop.ts` glue to remain shallow — call `keepalive.acquire()`, wrap `runStage` in `withRetries`, call `notify` on terminal events — so that the iteration logic stays readable.
+23. As a Ralph user, I want `Ctrl-C` to release the wake-lock cleanly, kill any pending docker child, and exit with a non-zero code, so that I can abort an AFK run without leaking OS state.
+24. As a Ralph user, I want `ralph-afk --help` and `ralph-ghafk --help` to document `--detach`, `--notify`, `--max-retries`, `--no-keep-alive`, and `--log`, so that the flags are discoverable without reading the README.
+25. As a Ralph user, I want the existing `--print-config` output extended to show "keep-alive: on (system sleep only)", "max-retries: 3", and "detach: off", so that I can verify the AFK configuration before kicking off an overnight run.
+26. As a Ralph user, I want `docs/keep-alive.md` rewritten to describe the new built-in behavior (what's automatic, what's opt-in, per-OS notes, troubleshooting), so that the documentation matches reality rather than copy-pasting another project's manual-recipe approach.
+27. As a Ralph user, I want power-loss / battery-death scenarios documented as out-of-scope for v1 (use a UPS or accept the loss), so that I have realistic expectations.
+
+## Implementation Decisions
+
+### Modules
+
+- **`keepalive` module (new, deep)** — pure cross-OS wake-lock dispatcher.
+  - Interface: `acquire(opts: { reason?: string; spawner?: Spawner }): Releaser` where `Releaser = { release: () => void }`.
+  - Platform dispatch:
+    - **Windows**: spawn a long-lived `powershell -NoProfile -Command "Add-Type ... [Power.PowerHelper]::SetThreadExecutionState([uint]::ES_CONTINUOUS -bor [uint]::ES_SYSTEM_REQUIRED); while ($true) { Start-Sleep -Seconds 60 }"` child. `release()` kills the child, which lets the OS clear `ES_CONTINUOUS` on process exit.
+    - **macOS**: spawn `caffeinate -i -w <parent-pid>`. `release()` kills the child; `-w` makes caffeinate self-terminate if the parent dies first, so a SIGKILL of the bin still cleans up.
+    - **Linux**: spawn `systemd-inhibit --what=sleep --why="<reason>" --mode=block sleep infinity`. `release()` kills the child.
+    - **WSL2**: detected via `/proc/version` containing `microsoft`. Emit a warning that the Linux `systemd-inhibit` only blocks WSL idle, not Windows host sleep; document the manual Windows power-plan recipe.
+    - **Missing utility / unsupported platform**: emit one-line warning to stderr, return a no-op releaser. Loop continues without wake-lock.
+  - The `spawner` parameter is dependency-injected to allow unit tests to assert per-OS argv without actually spawning processes.
+- **`retry` module (new, deep)** — pure backoff scheduler.
+  - Interface: `withRetries<T>(fn: () => Promise<T>, opts: { max: number; backoffMs: number[]; onAttempt?: (n, err) => void }): Promise<T>`.
+  - Behavior: invokes `fn` up to `max + 1` times. Between attempts, awaits `backoffMs[i]` (last value reused if attempts exceed array length). `onAttempt` fires before each retry for log emission. Final failure rethrows the last error.
+  - Default backoff: `[5_000, 30_000, 120_000]` (5s, 30s, 2m). Max retries: 3.
+- **`detach` module (new, medium)** — fork-and-exit driver.
+  - Interface: `detachAndExit(opts: { logPath: string; argv: string[]; binEntry: string }): never`.
+  - Implementation: `spawn(process.execPath, [binEntry, ...argvWithoutDetachFlag], { detached: true, stdio: ['ignore', logFd, logFd], windowsHide: true }).unref()`. Parent prints `detached pid <pid>, log <path>` and `process.exit(0)`.
+  - Edge cases: ensure `--detach` is stripped from the re-spawned argv to avoid an infinite fork loop. Ensure `process.execPath` is the user's actual node binary (not a shim that requires the parent tty).
+- **`notify` module (new, shallow)** — OS toast + bell dispatcher.
+  - Interface: `notify({ title: string; body: string; sound?: boolean; level: "info" | "error" }): void`.
+  - Platform dispatch (try in order, fall through silently on failure):
+    - **Windows**: try `powershell -Command "New-BurntToastNotification ..."` (if `BurntToast` module available), else fall back to `msg.exe * "<body>"`, else bell-only.
+    - **macOS**: `osascript -e 'display notification "<body>" with title "<title>" sound name "Glass"'`.
+    - **Linux**: `notify-send "<title>" "<body>"`.
+  - Bell: write `\x07` to stderr in addition to the OS notification.
+  - Fire-and-forget; do not block the loop on notification delivery.
+- **`loop.ts`** (modify, shallow glue) — wire wake-lock + retry + notify around the existing iteration loop.
+  - Acquire wake-lock before iteration 1; release in a `finally` covering signal handlers (`SIGINT`, `SIGTERM`).
+  - Wrap each `runStage(...)` call in `withRetries(...)` with the user's retry config. Log retry attempts via the existing stderr `[sandcastle]`-style channel and append a sentinel line to the NDJSON log.
+  - On clean completion (sentinel or iteration cap): call `notify({ level: "info", ... })` if enabled.
+  - On unrecoverable failure (e.g. all retries exhausted, signal received): call `notify({ level: "error", ... })`, release wake-lock, rethrow.
+- **`main.ts` / `gh-main.ts`** (modify, shallow glue) — argument parsing for new flags.
+  - `--detach` → call `detachAndExit` before any other side effects (so the wake-lock is acquired in the child, not orphaned in the parent).
+  - `--notify` → flips a flag passed into `runLoop`.
+  - `--no-keep-alive` → flips a flag passed into `runLoop`.
+  - `--max-retries <N>` → integer parse, validate `>= 0`, passed into `runLoop`.
+  - `--log <path>` → only meaningful with `--detach`; if absent, default to `.ralph-tmp/logs/detached-<pid>.log` after fork.
+- **`cli-help.ts`** (modify) — extend the help block with the new flag table.
+- **`docs/keep-alive.md`** (rewrite) — replace nightshift's three-recipe doc with the new built-in behavior, opt-in flag reference, and per-OS troubleshooting notes (WSL2 caveat, Windows admin-free wake-lock explanation, macOS / Linux utility requirements).
+- **`README.md`** (modify) — add a "Running AFK" section linking to `docs/keep-alive.md` and showing the canonical overnight-run recipe (`ralph-afk --detach --notify "<plan>" 50`).
+
+### Defaults & flag matrix
+
+| Flag                | Default                              | Behavior                                                                          |
+| ------------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
+| (none)              | —                                    | Wake-lock acquired, retries up to 3× with exponential backoff, foreground output. |
+| `--no-keep-alive`   | off                                  | Skip wake-lock entirely.                                                          |
+| `--max-retries <N>` | 3                                    | Per-iteration retry budget. `0` disables retries (current behavior).              |
+| `--detach`          | off                                  | Fork to background; print PID + log; exit.                                        |
+| `--log <path>`      | `.ralph-tmp/logs/detached-<pid>.log` | Detached-mode log target.                                                         |
+| `--notify`          | off                                  | OS toast + bell on loop terminal events.                                          |
+
+### Signal handling contract
+
+- `SIGINT` (Ctrl-C) and `SIGTERM`: release wake-lock, kill in-flight docker child, exit with the signal-conventional non-zero code (130 for SIGINT, 143 for SIGTERM).
+- Uncaught loop exception: release wake-lock, fire crash notification if `--notify` is on, rethrow so the process exits non-zero with the original stack trace.
+- All cleanup goes through a single `finally` + `process.on("exit", ...)` pair to guarantee the wake-lock child is killed exactly once.
+
+### `--print-config` extension
+
+Existing `--print-config` output gains three lines:
+
+```
+keep-alive   : on (system sleep only)
+max-retries  : 3
+detach       : off
+```
+
+When `--no-keep-alive` is passed: `keep-alive   : off`. When `--detach` is passed: `detach       : on (log: <path>)`.
+
+### Out-of-scope notification UX
+
+No notification grouping, no progress notifications mid-loop, no rich actions on the toast (e.g. "open log"). v1 is purely "loop is done" / "loop crashed" + bell. Progress is observed via the log; the toast is the wake-the-user signal.
+
+## Testing Decisions
+
+### What makes a good test here
+
+Tests target the **external behavior** of `keepalive` and `retry`:
+
+- For `keepalive`: given a platform string and a stubbed spawner, assert the exact argv passed to spawn AND that `release()` kills the returned child. The contract under test is "the right child gets started, and stops cleanly on release" — not the internal platform-dispatch branching.
+- For `retry`: given a stubbed function that fails N times then succeeds, assert the total number of attempts, the delay between attempts (via fake timers), and that `onAttempt` was called with the expected arguments. The contract under test is "fn is invoked until success or budget exhausted, with the documented backoff" — not the internal scheduling implementation.
+
+Tests that mock module internals (`fs`, `child_process` modulewise rather than via the injected `spawner`) survive nothing and rot fast.
+
+### Modules under test
+
+- **`keepalive`** — three platform branches × release-cleanup × utility-missing fallback. Non-trivial dispatch, the only module where a typo silently produces a no-op on prod machines.
+- **`retry`** — pure scheduler. Trivial to unit-test, valuable because the loop relies on it being correct (a buggy retry could re-trigger the same expensive iteration forever).
+
+Out of scope for unit tests: `detach` (re-execs the node binary; meaningfully tested only end-to-end), `notify` (shallow fan-out where a manual smoke per OS is faster and more reliable than mocking spawn), `loop.ts` glue (covered by the existing manual smoke flow).
+
+### Test framework
+
+Add `vitest` to `packages/core` `devDependencies` and a `"test": "vitest run"` script. (`vitest` does not ship in the published `files` array; the npm tarball is unaffected.) This matches the framework chosen in the multi-version-runtime-support PRD, keeping the project on one test stack.
+
+### Concrete test cases
+
+**`keepalive`**:
+
+- Windows path: spawner receives `["powershell", "-NoProfile", "-Command", "<script containing SetThreadExecutionState>"]`. Release kills child.
+- macOS path: spawner receives `["caffeinate", "-i", "-w", "<pid>"]` with parent pid. Release kills child.
+- Linux path: spawner receives `["systemd-inhibit", "--what=sleep", "--why=...", "--mode=block", "sleep", "infinity"]`. Release kills child.
+- WSL2 detection: when `/proc/version` contains `microsoft`, a warning is emitted and the Linux path still runs.
+- Missing utility (spawner throws `ENOENT`): warning emitted, no-op releaser returned, `release()` is a safe no-op.
+
+**`retry`**:
+
+- Success on first attempt: fn called once, no delay, returns value.
+- Success on third attempt: fn called three times, delays `[5_000, 30_000]` observed via fake timers, returns final value.
+- Persistent failure with `max: 3`: fn called four times total, delays `[5_000, 30_000, 120_000]` observed, final error rethrown.
+- `max: 0`: fn called once, no retry, error rethrown immediately.
+- `onAttempt` callback fired before each retry with `(attemptNumber, error)`.
+
+### Prior art
+
+None in this repo (no test suite exists today). The multi-version-runtime-support PRD already proposes adding `vitest` for its `detect` module; this PRD assumes that landed and shares the same test framework. If the runtime PRD ships after this one, this PRD pulls the `vitest` setup forward.
+
+## Out of Scope
+
+- **Power-loss / UPS scenarios** — if the laptop battery dies or the desk loses power, the loop dies. Out of scope for v1. Document the UPS recommendation in `docs/keep-alive.md`.
+- **Resume on restart** — if the docker host reboots, the loop does not resume from iteration N+1. Out of scope (deferred per the runtime-support PRD's "punt complexity, the commits in the workspace are the real resume mechanism" reasoning). Cheap follow-up if demand surfaces.
+- **Daemon mode with reattach** — `--detach` forks-and-forgets. No `ralph-afk attach <pid>` command; users `tail -f <log>` for visibility. A real reattach surface is a separate, larger PRD.
+- **Progress notifications mid-loop** — only completion / crash notifications in v1. No "iteration 25/50 done" toasts.
+- **Notification grouping / rich actions** — plain text title + body + bell. No Action Center categorization, no clickable actions on the toast.
+- **GUI status panel** — no tray icon, no menubar widget. Out of scope.
+- **Non-OS power management** — no integration with macOS Power Nap, no Windows Modern Standby tuning beyond `SetThreadExecutionState`. The wake-lock blocks idle sleep; if the user manually puts the laptop to sleep, the loop dies as expected.
+- **Battery threshold gating** — no "pause loop when battery < 20%" logic. The user knows their setup.
+- **WSL2 → Windows host wake-lock bridge** — a working solution would require a Windows-side helper process. Out of scope; document the limitation and recommend running natively on Windows for AFK use.
+
+## Further Notes
+
+### Open risks the implementer should investigate
+
+1. **Windows `SetThreadExecutionState` via PowerShell child process** — the `Add-Type` approach pins the wake-lock to the lifetime of that powershell process. Verify on Windows 11 that killing the powershell child releases the lock immediately (not at the next idle-check tick). If the lock leaks past the child's death, fall back to spawning a tiny Node child that calls the same Win32 API via `node-ffi-napi` (extra dep) or `koffi`.
+2. **macOS `caffeinate -w <pid>` race** — if the parent crashes between `caffeinate` spawn and the explicit `release()`, does caffeinate notice the parent is gone and exit on its own? Manual test required; the `-w` flag is documented to handle exactly this, but verify with a forced SIGKILL.
+3. **Linux `systemd-inhibit` outside systemd-managed sessions** — some minimal container or chroot environments do not have a working systemd user session. Detect this (probe for `systemctl is-system-running`) and degrade to a warning rather than a hung `systemd-inhibit` call.
+4. **WSL2 nuance** — `systemd-inhibit` may work inside WSL2 if the user enabled systemd in `/etc/wsl.conf`, but it only blocks WSL idle, not Windows host sleep. The implementer should test both with and without systemd-on-wsl2 and emit a clear warning either way.
+5. **Detach + log file ownership on Windows** — when `spawn` creates the child process with `detached: true` on Windows, the log file handle must be opened before spawn and inherited correctly. Verify that closing the parent's handle doesn't truncate the file.
+6. **Notification dependency footprint** — BurntToast is a separate PowerShell module (`Install-Module BurntToast`). Don't auto-install; detect and fall back to `msg.exe` + bell. Document the optional install in `docs/keep-alive.md`.
+7. **Retry budget vs iteration cost** — three retries with 5s/30s/2m backoff means a single bad iteration can stall the loop for ~3 minutes before skipping. For a 50-iteration overnight run that's negligible; for short interactive runs it's painful. The `--max-retries 0` opt-out is sufficient mitigation; verify the default doesn't surprise short-run users.
+
+### Files to touch
+
+- `packages/core/src/keepalive.ts` (new — deep module)
+- `packages/core/src/retry.ts` (new — deep module)
+- `packages/core/src/detach.ts` (new — medium module)
+- `packages/core/src/notify.ts` (new — shallow module)
+- `packages/core/src/loop.ts` (wire wake-lock + retry + notify)
+- `packages/core/src/main.ts` (parse new flags, detach before runLoop)
+- `packages/core/src/gh-main.ts` (parse new flags, detach before runLoop)
+- `packages/core/src/cli-help.ts` (document new flags)
+- `packages/core/src/__tests__/keepalive.test.ts` (new — unit tests)
+- `packages/core/src/__tests__/retry.test.ts` (new — unit tests)
+- `packages/core/package.json` (add `vitest` devDep + `test` script)
+- `apps/cli/bin/ralph-afk` (forward new flags to runLoop)
+- `apps/cli/bin/ralph-ghafk` (forward new flags to runLoop)
+- `docs/keep-alive.md` (rewrite for new built-in behavior)
+- `README.md` (new "Running AFK" section)
+
+### Verification
+
+End-to-end smoke after merge, in order:
+
+1. `pnpm install && pnpm -r build && pnpm -r typecheck` — clean.
+2. `pnpm --filter @daonhan/ralph-core test` — `keepalive.test.ts` + `retry.test.ts` green.
+3. Windows 11: `ralph-afk "<short plan>" 3` — confirm via `powercfg /requests` that a `SYSTEM` request is held during the run, released after exit.
+4. macOS: `ralph-afk "<short plan>" 3` — confirm via `pmset -g assertions` that `PreventUserIdleSystemSleep` is held during the run.
+5. Linux: `ralph-afk "<short plan>" 3` — confirm via `systemd-inhibit --list` that the inhibitor is present during the run.
+6. `ralph-afk --max-retries 1 "<plan>" 1` against a plan known to fail; verify exactly one retry happens, then the iteration is logged as failed and skipped, and the loop reports clean exit.
+7. `ralph-afk --detach "<plan>" 3` — confirm process detaches, parent exits, log file gets written, target terminal can be closed without killing the loop. Tail the log from a fresh shell.
+8. `ralph-afk --notify "<plan>" 3` — confirm OS toast appears on completion and bell rings.
+9. `ralph-afk --print-config` — confirm new lines appear and reflect flag combinations correctly.
+10. `Ctrl-C` mid-run — confirm wake-lock child dies (verify via the same OS-specific probe as steps 3–5), docker child dies, exit code is 130.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "build": "tsc -p tsconfig.json",
     "clean": "node -e \"const fs=require('node:fs');fs.rmSync('dist',{recursive:true,force:true});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
     "prepublishOnly": "pnpm run clean && pnpm run build"
   },
   "engines": {
@@ -39,5 +40,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.7"
   }
 }

--- a/packages/core/src/__tests__/detach.test.ts
+++ b/packages/core/src/__tests__/detach.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  detachAndExit,
+  stripDetachFlags,
+  type DetachOptions,
+  type DetachedChild,
+} from "../detach.js";
+
+describe("stripDetachFlags", () => {
+  it("removes --detach when present", () => {
+    expect(stripDetachFlags(["--detach", "plan", "3"])).toEqual(["plan", "3"]);
+  });
+
+  it("removes --log and its value when present", () => {
+    expect(stripDetachFlags(["--log", "/tmp/a.log", "plan", "3"])).toEqual([
+      "plan",
+      "3",
+    ]);
+  });
+
+  it("removes both --detach and --log <value> while preserving other flags", () => {
+    expect(
+      stripDetachFlags([
+        "--no-keep-alive",
+        "--detach",
+        "--max-retries",
+        "5",
+        "--log",
+        "/tmp/a.log",
+        "plan",
+        "3",
+      ])
+    ).toEqual(["--no-keep-alive", "--max-retries", "5", "plan", "3"]);
+  });
+
+  it("is a no-op when neither flag is present", () => {
+    expect(stripDetachFlags(["plan", "3"])).toEqual(["plan", "3"]);
+  });
+});
+
+type SpawnCall = {
+  cmd: string;
+  args: readonly string[];
+  options: {
+    detached: boolean;
+    stdio: readonly ["ignore", number, number];
+    windowsHide: boolean;
+  };
+};
+
+function makeCtx(overrides: Partial<DetachOptions> = {}) {
+  const spawnCalls: SpawnCall[] = [];
+  const fakeChild: DetachedChild & { unref: ReturnType<typeof vi.fn> } = {
+    pid: 99999,
+    unref: vi.fn(),
+  };
+  const spawnFn = vi.fn((cmd, args, options) => {
+    spawnCalls.push({ cmd, args, options });
+    return fakeChild;
+  });
+  const stderr = { write: vi.fn() };
+  const exit = vi.fn((_code?: number) => {
+    throw new Error("__exit__");
+  }) as unknown as (code?: number) => never;
+  const ensureDir = vi.fn();
+  const openFd = vi.fn(() => 42);
+  const opts: DetachOptions = {
+    logPath: "/tmp/x/y.log",
+    argv: ["--detach", "plan", "3"],
+    binEntry: "/path/to/ralph-afk.js",
+    execPath: "/usr/bin/node",
+    spawnFn,
+    openFd,
+    ensureDir,
+    stderr,
+    exit,
+    ...overrides,
+  };
+  return { opts, spawnCalls, fakeChild, stderr, exit, ensureDir, openFd };
+}
+
+describe("detachAndExit", () => {
+  it("ensures log dir, opens fd, spawns child with stripped argv + detached options, unrefs, writes stderr, exits 0", () => {
+    const ctx = makeCtx();
+
+    expect(() => detachAndExit(ctx.opts)).toThrow("__exit__");
+
+    expect(ctx.ensureDir).toHaveBeenCalledWith("/tmp/x");
+    expect(ctx.openFd).toHaveBeenCalledWith("/tmp/x/y.log");
+
+    expect(ctx.spawnCalls).toHaveLength(1);
+    expect(ctx.spawnCalls[0].cmd).toBe("/usr/bin/node");
+    expect(ctx.spawnCalls[0].args).toEqual([
+      "/path/to/ralph-afk.js",
+      "plan",
+      "3",
+    ]);
+    expect(ctx.spawnCalls[0].options).toEqual({
+      detached: true,
+      stdio: ["ignore", 42, 42],
+      windowsHide: true,
+    });
+
+    expect(ctx.fakeChild.unref).toHaveBeenCalledTimes(1);
+    expect(ctx.stderr.write).toHaveBeenCalledWith(
+      "detached pid 99999, log /tmp/x/y.log\n"
+    );
+    expect(ctx.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("strips --log <value> from the child argv too", () => {
+    const ctx = makeCtx({
+      argv: ["--detach", "--log", "/tmp/old.log", "plan", "3"],
+    });
+
+    expect(() => detachAndExit(ctx.opts)).toThrow("__exit__");
+
+    expect(ctx.spawnCalls[0].args).toEqual([
+      "/path/to/ralph-afk.js",
+      "plan",
+      "3",
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/keepalive.test.ts
+++ b/packages/core/src/__tests__/keepalive.test.ts
@@ -1,0 +1,139 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+import { acquire, type SpawnedChild, type Spawner } from "../keepalive.js";
+
+type SpawnCall = {
+  command: string;
+  args: readonly string[];
+  options: { detached?: boolean; stdio?: "ignore" };
+  child: FakeChild;
+};
+
+class FakeChild extends EventEmitter {
+  public pid = 12345;
+  public kill = vi.fn();
+}
+
+function makeSpawner(): { spawner: Spawner; calls: SpawnCall[] } {
+  const calls: SpawnCall[] = [];
+  const spawner: Spawner = (command, args, options) => {
+    const child = new FakeChild();
+    calls.push({ command, args, options, child });
+    return child as unknown as SpawnedChild;
+  };
+  return { spawner, calls };
+}
+
+describe("acquire", () => {
+  it("windows: spawns powershell with SetThreadExecutionState script", () => {
+    const { spawner, calls } = makeSpawner();
+    const warn = vi.fn();
+    const releaser = acquire({ platform: "win32", spawner, warn });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("powershell");
+    expect(calls[0].args).toEqual([
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      expect.stringContaining("SetThreadExecutionState"),
+    ]);
+    expect(warn).not.toHaveBeenCalled();
+
+    releaser.release();
+    expect(calls[0].child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("darwin: spawns caffeinate -i -w <pid>", () => {
+    const { spawner, calls } = makeSpawner();
+    const releaser = acquire({
+      platform: "darwin",
+      spawner,
+      parentPid: 4242,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("caffeinate");
+    expect(calls[0].args).toEqual(["-i", "-w", "4242"]);
+
+    releaser.release();
+    expect(calls[0].child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("linux: spawns systemd-inhibit with --what=sleep", () => {
+    const { spawner, calls } = makeSpawner();
+    const releaser = acquire({
+      platform: "linux",
+      spawner,
+      reason: "test-run",
+      wslHint: () => false,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("systemd-inhibit");
+    expect(calls[0].args).toEqual([
+      "--what=sleep",
+      "--why=test-run",
+      "--mode=block",
+      "sleep",
+      "infinity",
+    ]);
+
+    releaser.release();
+    expect(calls[0].child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("WSL2: emits a warning and still runs the linux path", () => {
+    const { spawner, calls } = makeSpawner();
+    const warn = vi.fn();
+    acquire({
+      platform: "linux",
+      spawner,
+      wslHint: () => true,
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/WSL2/);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("systemd-inhibit");
+  });
+
+  it("missing utility (ENOENT): warns once and returns a safe no-op releaser", () => {
+    const warn = vi.fn();
+    const spawner: Spawner = () => {
+      const err = new Error("spawn caffeinate ENOENT") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    };
+
+    const releaser = acquire({ platform: "darwin", spawner, warn });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/caffeinate not found/);
+    expect(() => releaser.release()).not.toThrow();
+  });
+
+  it("unsupported platform: warns and returns a no-op releaser", () => {
+    const warn = vi.fn();
+    const { spawner, calls } = makeSpawner();
+    const releaser = acquire({
+      platform: "freebsd" as NodeJS.Platform,
+      spawner,
+      warn,
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/unsupported platform/);
+    expect(calls).toHaveLength(0);
+    expect(() => releaser.release()).not.toThrow();
+  });
+
+  it("release is idempotent: kill only fires once", () => {
+    const { spawner, calls } = makeSpawner();
+    const releaser = acquire({ platform: "darwin", spawner });
+    releaser.release();
+    releaser.release();
+    expect(calls[0].child.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/__tests__/keepalive.test.ts
+++ b/packages/core/src/__tests__/keepalive.test.ts
@@ -136,4 +136,16 @@ describe("acquire", () => {
     releaser.release();
     expect(calls[0].child.kill).toHaveBeenCalledTimes(1);
   });
+
+  it("warns when the wake-lock child exits before release", () => {
+    const { spawner, calls } = makeSpawner();
+    const warn = vi.fn();
+    acquire({ platform: "linux", spawner, warn, wslHint: () => false });
+
+    calls[0].child.emit("close", 1, null);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/exited early/);
+    expect(warn.mock.calls[0][0]).toMatch(/continuing without wake-lock/);
+  });
 });

--- a/packages/core/src/__tests__/loop.test.ts
+++ b/packages/core/src/__tests__/loop.test.ts
@@ -206,4 +206,36 @@ describe("runLoop", () => {
     expect(mocks.release).toHaveBeenCalledTimes(1);
     expect(exit).toHaveBeenCalledWith(130);
   });
+
+  it("aborts image setup and releases the wake-lock on SIGTERM", async () => {
+    const dirs = makeDirs();
+    roots.push(dirs.root);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    let capturedSignal: AbortSignal | undefined;
+    mocks.ensureImage.mockImplementation((_ralphDir, options) => {
+      capturedSignal = options.signal;
+      return new Promise((_resolve, reject) => {
+        capturedSignal!.addEventListener("abort", () =>
+          reject(new Error("image aborted"))
+        );
+      });
+    });
+
+    const loop = runLoop(loopOptions(dirs));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(capturedSignal?.aborted).toBe(false);
+    expect(() => process.emit("SIGTERM")).toThrow("exit 143");
+
+    expect(capturedSignal?.aborted).toBe(true);
+    await expect(loop).rejects.toThrow("image aborted");
+    expect(mocks.runStage).not.toHaveBeenCalled();
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(143);
+  });
 });

--- a/packages/core/src/__tests__/loop.test.ts
+++ b/packages/core/src/__tests__/loop.test.ts
@@ -1,0 +1,209 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Stage } from "../stages.js";
+
+const mocks = vi.hoisted(() => ({
+  acquire: vi.fn(),
+  ensureImage: vi.fn(),
+  notifyComplete: vi.fn(),
+  notifyError: vi.fn(),
+  release: vi.fn(),
+  runStage: vi.fn(),
+}));
+
+vi.mock("../keepalive.js", () => ({
+  acquire: mocks.acquire,
+}));
+
+vi.mock("../notify.js", () => ({
+  notifyComplete: mocks.notifyComplete,
+  notifyError: mocks.notifyError,
+}));
+
+vi.mock("../runner.js", () => ({
+  ensureImage: mocks.ensureImage,
+  runStage: mocks.runStage,
+  stageLogPath: (workspaceDir: string, iteration: number, stageName: string) =>
+    join(
+      workspaceDir,
+      ".ralph-tmp",
+      "logs",
+      `iter${iteration}-${stageName}.ndjson`
+    ),
+  USE_COLOR: false,
+  dim: (s: string) => s,
+  bold: (s: string) => s,
+  red: (s: string) => s,
+  greenOut: (s: string) => s,
+  boldOut: (s: string) => s,
+  dimOut: (s: string) => s,
+  SYM: { cross: "FAIL" },
+  SYM_OUT: { bullet: "*" },
+}));
+
+import { runLoop } from "../loop.js";
+
+const stage: Stage = { name: "implementer", template: "stage.md" };
+const sentinel = "<promise>NO MORE TASKS</promise>";
+
+type LoopDirs = {
+  root: string;
+  ralphDir: string;
+  sandcastleDir: string;
+  workspaceDir: string;
+};
+
+function makeDirs(): LoopDirs {
+  const root = mkdtempSync(join(tmpdir(), "ralph-loop-"));
+  const ralphDir = join(root, "ralph");
+  const sandcastleDir = join(root, "sandcastle");
+  const workspaceDir = join(root, "workspace");
+
+  mkdirSync(join(sandcastleDir, "templates"), { recursive: true });
+  mkdirSync(ralphDir, { recursive: true });
+  mkdirSync(workspaceDir, { recursive: true });
+  writeFileSync(
+    join(sandcastleDir, "templates", stage.template),
+    "run {{ INPUTS }}",
+    "utf8"
+  );
+
+  return { root, ralphDir, sandcastleDir, workspaceDir };
+}
+
+function loopOptions(dirs: LoopDirs, overrides = {}) {
+  return {
+    stages: [stage] as [Stage],
+    inputs: "plan",
+    iterations: 1,
+    ralphDir: dirs.ralphDir,
+    workspaceDir: dirs.workspaceDir,
+    sandcastleDir: dirs.sandcastleDir,
+    ...overrides,
+  };
+}
+
+describe("runLoop", () => {
+  const roots: string[] = [];
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    for (const mock of Object.values(mocks)) mock.mockReset();
+    mocks.acquire.mockReturnValue({ release: mocks.release });
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    while (roots.length > 0) {
+      rmSync(roots.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  it("acquires the wake-lock before image setup and releases on completion", async () => {
+    const dirs = makeDirs();
+    roots.push(dirs.root);
+    const order: string[] = [];
+    mocks.acquire.mockImplementation(() => {
+      order.push("acquire");
+      return { release: mocks.release };
+    });
+    mocks.ensureImage.mockImplementation(() => {
+      order.push("ensureImage");
+    });
+    mocks.runStage.mockResolvedValue(sentinel);
+
+    await runLoop(loopOptions(dirs, { notify: true }));
+
+    expect(order).toEqual(["acquire", "ensureImage"]);
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+    expect(mocks.notifyComplete).toHaveBeenCalledWith(1, true);
+  });
+
+  it("logs terminal stage failure and continues with the next iteration", async () => {
+    const dirs = makeDirs();
+    roots.push(dirs.root);
+    mocks.runStage
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(sentinel);
+
+    await runLoop(loopOptions(dirs, { iterations: 2, maxRetries: 0 }));
+
+    expect(mocks.runStage).toHaveBeenCalledTimes(2);
+    const firstLog = readFileSync(
+      join(dirs.workspaceDir, ".ralph-tmp", "logs", "iter1-implementer.ndjson"),
+      "utf8"
+    );
+    expect(firstLog).toContain(
+      "[failure] iteration 1 stage implementer failed after 0 retries: boom"
+    );
+  });
+
+  it("retries a failed stage before continuing", async () => {
+    vi.useFakeTimers();
+    const dirs = makeDirs();
+    roots.push(dirs.root);
+    mocks.runStage
+      .mockRejectedValueOnce(new Error("flaky"))
+      .mockResolvedValueOnce(sentinel);
+
+    const loop = runLoop(loopOptions(dirs, { maxRetries: 1 }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.runStage).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await loop;
+
+    expect(mocks.runStage).toHaveBeenCalledTimes(2);
+    const firstLog = readFileSync(
+      join(dirs.workspaceDir, ".ralph-tmp", "logs", "iter1-implementer.ndjson"),
+      "utf8"
+    );
+    expect(firstLog).toContain("[retry] attempt 1 of 1 after 5000 ms");
+  });
+
+  it("aborts the active stage and releases the wake-lock on SIGINT", async () => {
+    const dirs = makeDirs();
+    roots.push(dirs.root);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((
+      code?: number
+    ) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    let capturedSignal: AbortSignal | undefined;
+    mocks.runStage.mockImplementation(
+      (_stage, _prompt, _workspace, _iteration, _spill, _log, options) => {
+        capturedSignal = options.signal;
+        return new Promise((_resolve, reject) => {
+          capturedSignal!.addEventListener("abort", () =>
+            reject(new Error("aborted"))
+          );
+        });
+      }
+    );
+
+    const loop = runLoop(loopOptions(dirs, { maxRetries: 0 }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(capturedSignal?.aborted).toBe(false);
+    expect(() => process.emit("SIGINT")).toThrow("exit 130");
+
+    expect(capturedSignal?.aborted).toBe(true);
+    await loop;
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(130);
+  });
+});

--- a/packages/core/src/__tests__/notify.test.ts
+++ b/packages/core/src/__tests__/notify.test.ts
@@ -201,17 +201,17 @@ describe("notify", () => {
     expect(writes).toContain("\x07");
   });
 
-  it("body containing single quotes is safely escaped on darwin", () => {
+  it("body containing quotes and backslashes is safely escaped on darwin", () => {
     const { spawner, calls } = makeSpawner();
     const { stderr } = makeStderr();
     notify({
       level: "info",
       title: "title",
-      body: `hit "the" sentinel`,
+      body: `hit "the" C:\\tmp sentinel`,
       platform: "darwin",
       spawner,
       stderr,
     });
-    expect(calls[0].args[1]).toContain('hit \\"the\\" sentinel');
+    expect(calls[0].args[1]).toContain('hit \\"the\\" C:\\\\tmp sentinel');
   });
 });

--- a/packages/core/src/__tests__/notify.test.ts
+++ b/packages/core/src/__tests__/notify.test.ts
@@ -1,0 +1,217 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  notify,
+  type NotifySpawnedChild,
+  type NotifySpawner,
+} from "../notify.js";
+
+type SpawnCall = {
+  command: string;
+  args: readonly string[];
+  child: FakeChild;
+};
+
+class FakeChild extends EventEmitter {
+  public unref = vi.fn();
+}
+
+function makeSpawner(): { spawner: NotifySpawner; calls: SpawnCall[] } {
+  const calls: SpawnCall[] = [];
+  const spawner: NotifySpawner = (command, args) => {
+    const child = new FakeChild();
+    calls.push({ command, args, child });
+    return child as unknown as NotifySpawnedChild;
+  };
+  return { spawner, calls };
+}
+
+function makeStderr() {
+  const writes: string[] = [];
+  return {
+    stderr: { write: (s: string) => writes.push(s) },
+    writes,
+  };
+}
+
+describe("notify", () => {
+  it("writes \\x07 to stderr on every call", () => {
+    const { spawner } = makeSpawner();
+    const { stderr, writes } = makeStderr();
+    notify({
+      level: "info",
+      title: "t",
+      body: "b",
+      platform: "linux",
+      spawner,
+      stderr,
+    });
+    expect(writes).toContain("\x07");
+  });
+
+  it("sound:false suppresses the bell", () => {
+    const { spawner } = makeSpawner();
+    const { stderr, writes } = makeStderr();
+    notify({
+      level: "info",
+      title: "t",
+      body: "b",
+      sound: false,
+      platform: "linux",
+      spawner,
+      stderr,
+    });
+    expect(writes).not.toContain("\x07");
+  });
+
+  it("linux: invokes notify-send with normal urgency for info", () => {
+    const { spawner, calls } = makeSpawner();
+    const { stderr } = makeStderr();
+    notify({
+      level: "info",
+      title: "Ralph complete",
+      body: "done",
+      platform: "linux",
+      spawner,
+      stderr,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("notify-send");
+    expect(calls[0].args).toEqual([
+      "--urgency",
+      "normal",
+      "Ralph complete",
+      "done",
+    ]);
+    expect(calls[0].child.unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("linux: invokes notify-send with critical urgency for error", () => {
+    const { spawner, calls } = makeSpawner();
+    const { stderr } = makeStderr();
+    notify({
+      level: "error",
+      title: "Ralph failed",
+      body: "boom",
+      platform: "linux",
+      spawner,
+      stderr,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual([
+      "--urgency",
+      "critical",
+      "Ralph failed",
+      "boom",
+    ]);
+  });
+
+  it("darwin: invokes osascript display notification with Glass sound for info", () => {
+    const { spawner, calls } = makeSpawner();
+    const { stderr } = makeStderr();
+    notify({
+      level: "info",
+      title: "Ralph complete",
+      body: "done",
+      platform: "darwin",
+      spawner,
+      stderr,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("osascript");
+    expect(calls[0].args[0]).toBe("-e");
+    expect(calls[0].args[1]).toContain('display notification "done"');
+    expect(calls[0].args[1]).toContain('with title "Ralph complete"');
+    expect(calls[0].args[1]).toContain('sound name "Glass"');
+  });
+
+  it("darwin: uses a different sound for error", () => {
+    const { spawner, calls } = makeSpawner();
+    const { stderr } = makeStderr();
+    notify({
+      level: "error",
+      title: "Ralph failed",
+      body: "boom",
+      platform: "darwin",
+      spawner,
+      stderr,
+    });
+    expect(calls[0].args[1]).not.toContain('sound name "Glass"');
+    expect(calls[0].args[1]).toContain("sound name");
+  });
+
+  it("win32: tries BurntToast (powershell) then msg.exe", () => {
+    const { spawner, calls } = makeSpawner();
+    const { stderr } = makeStderr();
+    notify({
+      level: "info",
+      title: "Ralph complete",
+      body: "done",
+      platform: "win32",
+      spawner,
+      stderr,
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].command).toBe("powershell");
+    expect(calls[0].args).toEqual([
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      expect.stringContaining("BurntToast"),
+    ]);
+    expect(calls[1].command).toBe("msg.exe");
+    expect(calls[1].args).toEqual(["*", "Ralph complete: done"]);
+  });
+
+  it("missing utility (spawner throws ENOENT): bell still fires, no crash", () => {
+    const spawner: NotifySpawner = () => {
+      const err = new Error(
+        "spawn notify-send ENOENT"
+      ) as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    };
+    const { stderr, writes } = makeStderr();
+    expect(() =>
+      notify({
+        level: "info",
+        title: "t",
+        body: "b",
+        platform: "linux",
+        spawner,
+        stderr,
+      })
+    ).not.toThrow();
+    expect(writes).toContain("\x07");
+  });
+
+  it("unsupported platform: bell-only, no spawn attempt, no crash", () => {
+    const { spawner, calls } = makeSpawner();
+    const { stderr, writes } = makeStderr();
+    notify({
+      level: "info",
+      title: "t",
+      body: "b",
+      platform: "freebsd" as NodeJS.Platform,
+      spawner,
+      stderr,
+    });
+    expect(calls).toHaveLength(0);
+    expect(writes).toContain("\x07");
+  });
+
+  it("body containing single quotes is safely escaped on darwin", () => {
+    const { spawner, calls } = makeSpawner();
+    const { stderr } = makeStderr();
+    notify({
+      level: "info",
+      title: "title",
+      body: `hit "the" sentinel`,
+      platform: "darwin",
+      spawner,
+      stderr,
+    });
+    expect(calls[0].args[1]).toContain('hit \\"the\\" sentinel');
+  });
+});

--- a/packages/core/src/__tests__/retry.test.ts
+++ b/packages/core/src/__tests__/retry.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { withRetries, backoffFor } from "../retry.js";
+
+describe("withRetries", () => {
+  it("returns on first-attempt success without delay", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const onAttempt = vi.fn();
+
+    const result = await withRetries(fn, {
+      max: 3,
+      backoffMs: [5_000, 30_000, 120_000],
+      onAttempt,
+      sleep,
+    });
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(onAttempt).not.toHaveBeenCalled();
+  });
+
+  it("succeeds on third attempt with [5s, 30s] waits", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("e1"))
+      .mockRejectedValueOnce(new Error("e2"))
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withRetries(fn, {
+      max: 3,
+      backoffMs: [5_000, 30_000, 120_000],
+      sleep,
+    });
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([5_000, 30_000]);
+  });
+
+  it("persistent failure with max: 3 throws last error after four total calls and [5s, 30s, 2m] waits", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("e1"))
+      .mockRejectedValueOnce(new Error("e2"))
+      .mockRejectedValueOnce(new Error("e3"))
+      .mockRejectedValueOnce(new Error("e4"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      withRetries(fn, {
+        max: 3,
+        backoffMs: [5_000, 30_000, 120_000],
+        sleep,
+      })
+    ).rejects.toThrow("e4");
+
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([5_000, 30_000, 120_000]);
+  });
+
+  it("max: 0 throws immediately after a single call with no delays", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      withRetries(fn, { max: 0, backoffMs: [5_000], sleep })
+    ).rejects.toThrow("boom");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("onAttempt fires before each retry with (attemptNumber, error) in order", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("e1"))
+      .mockRejectedValueOnce(new Error("e2"))
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const onAttempt = vi.fn();
+
+    await withRetries(fn, {
+      max: 3,
+      backoffMs: [10, 20, 30],
+      onAttempt,
+      sleep,
+    });
+
+    expect(onAttempt).toHaveBeenCalledTimes(2);
+    expect(onAttempt.mock.calls[0][0]).toBe(1);
+    expect((onAttempt.mock.calls[0][1] as Error).message).toBe("e1");
+    expect(onAttempt.mock.calls[1][0]).toBe(2);
+    expect((onAttempt.mock.calls[1][1] as Error).message).toBe("e2");
+  });
+});
+
+describe("backoffFor", () => {
+  it("returns the per-attempt backoff and reuses the last value past the end", () => {
+    const b = [5_000, 30_000, 120_000];
+    expect(backoffFor(b, 1)).toBe(5_000);
+    expect(backoffFor(b, 2)).toBe(30_000);
+    expect(backoffFor(b, 3)).toBe(120_000);
+    expect(backoffFor(b, 4)).toBe(120_000);
+    expect(backoffFor([], 1)).toBe(0);
+  });
+});

--- a/packages/core/src/cli-help.ts
+++ b/packages/core/src/cli-help.ts
@@ -13,6 +13,7 @@ export type CliFlags = {
   help: boolean;
   version: boolean;
   printConfig: boolean;
+  noKeepAlive: boolean;
   rest: string[];
 };
 
@@ -20,14 +21,16 @@ export function parseFlags(argv: string[]): CliFlags {
   let help = false;
   let version = false;
   let printConfig = false;
+  let noKeepAlive = false;
   const rest: string[] = [];
   for (const a of argv) {
     if (a === "-h" || a === "--help") help = true;
     else if (a === "-V" || a === "--version") version = true;
     else if (a === "--print-config") printConfig = true;
+    else if (a === "--no-keep-alive") noKeepAlive = true;
     else rest.push(a);
   }
-  return { help, version, printConfig, rest };
+  return { help, version, printConfig, noKeepAlive, rest };
 }
 
 /**
@@ -72,6 +75,7 @@ Flags:
   -h, --help          show this help and exit
   -V, --version       print bin + core version and exit
   --print-config      resolve workspace / docker context / image / docker socket, print, exit without launching docker
+  --no-keep-alive     skip OS wake-lock acquisition (default: acquire system-sleep inhibitor for loop lifetime)
 
 Environment variables:
   RALPH_WORKSPACE       host dir bind-mounted at /home/agent/workspace (default: cwd)
@@ -96,13 +100,19 @@ Build fallback runs only if pull fails AND $RALPH_DOCKER_CONTEXT/Dockerfile exis
 `);
 }
 
+export type PrintConfigOptions = {
+  cliVersion?: string;
+  noKeepAlive?: boolean;
+};
+
 export function printConfig(
   bin: string,
   workspaceDir: string,
   ralphDir: string,
   sandcastleDir: string,
-  cliVersion?: string
+  opts: PrintConfigOptions = {}
 ): void {
+  const { cliVersion, noKeepAlive = false } = opts;
   const dockerfile = resolveDockerfile(ralphDir);
   const dfPresent = existsSync(dockerfile);
   const core = readCoreVersion();
@@ -130,6 +140,8 @@ export function printConfig(
     sockStatus = `mounting ${detectedSock} (${sockSource})${groupAdd ? `, --group-add ${groupAdd}` : ""}`;
   }
 
+  const keepAliveStatus = noKeepAlive ? "off" : "on (system sleep only)";
+
   process.stdout.write(`[${bin}] resolved config
   version               ${bin} ${cli} (core ${core})
   RALPH_WORKSPACE       ${workspaceDir}${process.env.RALPH_WORKSPACE ? "" : "  (default: cwd)"}
@@ -138,5 +150,6 @@ export function printConfig(
   Dockerfile at ctx     ${dfPresent ? "present" : "MISSING"} (${dockerfile})
   sandcastleDir         ${sandcastleDir}
   RALPH_DOCKER_SOCK     ${sockStatus}
+  keep-alive            ${keepAliveStatus}
 `);
 }

--- a/packages/core/src/cli-help.ts
+++ b/packages/core/src/cli-help.ts
@@ -127,7 +127,7 @@ Flags:
   --no-keep-alive     skip OS wake-lock acquisition (default: acquire system-sleep inhibitor for loop lifetime)
   --max-retries <N>   per-stage retry budget on transient failure (default: 3; 0 disables retries)
   --detach            fork the loop into a background process, print pid + log path, and exit (parent returns 0)
-  --log <path>        override the detached log path (default: <workspace>/.ralph-tmp/logs/detached-<pid>.log; requires --detach)
+  --log <path>        override the detached log path (default: <workspace>/.ralph-tmp/logs/detached-<parent-pid>.log; requires --detach)
   --notify            emit OS notification + terminal bell on loop completion or unrecoverable failure (default: off)
 
 Environment variables:

--- a/packages/core/src/cli-help.ts
+++ b/packages/core/src/cli-help.ts
@@ -16,6 +16,8 @@ export type CliFlags = {
   printConfig: boolean;
   noKeepAlive: boolean;
   maxRetries?: number;
+  detach: boolean;
+  log?: string;
   rest: string[];
 };
 
@@ -26,6 +28,9 @@ export function parseFlags(argv: string[]): CliFlags {
   let noKeepAlive = false;
   let maxRetries: number | undefined;
   let expectingMaxRetries = false;
+  let detach = false;
+  let log: string | undefined;
+  let expectingLog = false;
   const rest: string[] = [];
   for (const a of argv) {
     if (expectingMaxRetries) {
@@ -38,17 +43,39 @@ export function parseFlags(argv: string[]): CliFlags {
       expectingMaxRetries = false;
       continue;
     }
+    if (expectingLog) {
+      log = a;
+      expectingLog = false;
+      continue;
+    }
     if (a === "-h" || a === "--help") help = true;
     else if (a === "-V" || a === "--version") version = true;
     else if (a === "--print-config") printConfig = true;
     else if (a === "--no-keep-alive") noKeepAlive = true;
     else if (a === "--max-retries") expectingMaxRetries = true;
+    else if (a === "--detach") detach = true;
+    else if (a === "--log") expectingLog = true;
     else rest.push(a);
   }
   if (expectingMaxRetries) {
     throw new Error("--max-retries requires a value");
   }
-  return { help, version, printConfig, noKeepAlive, maxRetries, rest };
+  if (expectingLog) {
+    throw new Error("--log requires a value");
+  }
+  if (log !== undefined && !detach) {
+    throw new Error("--log is only meaningful with --detach");
+  }
+  return {
+    help,
+    version,
+    printConfig,
+    noKeepAlive,
+    maxRetries,
+    detach,
+    log,
+    rest,
+  };
 }
 
 /**
@@ -95,6 +122,8 @@ Flags:
   --print-config      resolve workspace / docker context / image / docker socket, print, exit without launching docker
   --no-keep-alive     skip OS wake-lock acquisition (default: acquire system-sleep inhibitor for loop lifetime)
   --max-retries <N>   per-stage retry budget on transient failure (default: 3; 0 disables retries)
+  --detach            fork the loop into a background process, print pid + log path, and exit (parent returns 0)
+  --log <path>        override the detached log path (default: <workspace>/.ralph-tmp/logs/detached-<pid>.log; requires --detach)
 
 Environment variables:
   RALPH_WORKSPACE       host dir bind-mounted at /home/agent/workspace (default: cwd)
@@ -123,6 +152,8 @@ export type PrintConfigOptions = {
   cliVersion?: string;
   noKeepAlive?: boolean;
   maxRetries?: number;
+  detach?: boolean;
+  detachLogPath?: string;
 };
 
 export function printConfig(
@@ -136,6 +167,8 @@ export function printConfig(
     cliVersion,
     noKeepAlive = false,
     maxRetries = DEFAULT_MAX_RETRIES,
+    detach = false,
+    detachLogPath,
   } = opts;
   const dockerfile = resolveDockerfile(ralphDir);
   const dfPresent = existsSync(dockerfile);
@@ -165,6 +198,8 @@ export function printConfig(
   }
 
   const keepAliveStatus = noKeepAlive ? "off" : "on (system sleep only)";
+  const detachStatus =
+    detach && detachLogPath ? `on (log: ${detachLogPath})` : "off";
 
   process.stdout.write(`[${bin}] resolved config
   version               ${bin} ${cli} (core ${core})
@@ -176,5 +211,6 @@ export function printConfig(
   RALPH_DOCKER_SOCK     ${sockStatus}
   keep-alive            ${keepAliveStatus}
   max-retries           ${maxRetries}
+  detach                ${detachStatus}
 `);
 }

--- a/packages/core/src/cli-help.ts
+++ b/packages/core/src/cli-help.ts
@@ -18,6 +18,7 @@ export type CliFlags = {
   maxRetries?: number;
   detach: boolean;
   log?: string;
+  notify: boolean;
   rest: string[];
 };
 
@@ -31,6 +32,7 @@ export function parseFlags(argv: string[]): CliFlags {
   let detach = false;
   let log: string | undefined;
   let expectingLog = false;
+  let notify = false;
   const rest: string[] = [];
   for (const a of argv) {
     if (expectingMaxRetries) {
@@ -55,6 +57,7 @@ export function parseFlags(argv: string[]): CliFlags {
     else if (a === "--max-retries") expectingMaxRetries = true;
     else if (a === "--detach") detach = true;
     else if (a === "--log") expectingLog = true;
+    else if (a === "--notify") notify = true;
     else rest.push(a);
   }
   if (expectingMaxRetries) {
@@ -74,6 +77,7 @@ export function parseFlags(argv: string[]): CliFlags {
     maxRetries,
     detach,
     log,
+    notify,
     rest,
   };
 }
@@ -124,6 +128,7 @@ Flags:
   --max-retries <N>   per-stage retry budget on transient failure (default: 3; 0 disables retries)
   --detach            fork the loop into a background process, print pid + log path, and exit (parent returns 0)
   --log <path>        override the detached log path (default: <workspace>/.ralph-tmp/logs/detached-<pid>.log; requires --detach)
+  --notify            emit OS notification + terminal bell on loop completion or unrecoverable failure (default: off)
 
 Environment variables:
   RALPH_WORKSPACE       host dir bind-mounted at /home/agent/workspace (default: cwd)
@@ -154,6 +159,7 @@ export type PrintConfigOptions = {
   maxRetries?: number;
   detach?: boolean;
   detachLogPath?: string;
+  notify?: boolean;
 };
 
 export function printConfig(
@@ -169,6 +175,7 @@ export function printConfig(
     maxRetries = DEFAULT_MAX_RETRIES,
     detach = false,
     detachLogPath,
+    notify = false,
   } = opts;
   const dockerfile = resolveDockerfile(ralphDir);
   const dfPresent = existsSync(dockerfile);
@@ -200,6 +207,7 @@ export function printConfig(
   const keepAliveStatus = noKeepAlive ? "off" : "on (system sleep only)";
   const detachStatus =
     detach && detachLogPath ? `on (log: ${detachLogPath})` : "off";
+  const notifyStatus = notify ? "on" : "off";
 
   process.stdout.write(`[${bin}] resolved config
   version               ${bin} ${cli} (core ${core})
@@ -212,5 +220,6 @@ export function printConfig(
   keep-alive            ${keepAliveStatus}
   max-retries           ${maxRetries}
   detach                ${detachStatus}
+  notify                ${notifyStatus}
 `);
 }

--- a/packages/core/src/cli-help.ts
+++ b/packages/core/src/cli-help.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { DEFAULT_MAX_RETRIES } from "./retry.js";
 import {
   IMAGE_REF,
   detectDockerSocketPath,
@@ -14,6 +15,7 @@ export type CliFlags = {
   version: boolean;
   printConfig: boolean;
   noKeepAlive: boolean;
+  maxRetries?: number;
   rest: string[];
 };
 
@@ -22,15 +24,31 @@ export function parseFlags(argv: string[]): CliFlags {
   let version = false;
   let printConfig = false;
   let noKeepAlive = false;
+  let maxRetries: number | undefined;
+  let expectingMaxRetries = false;
   const rest: string[] = [];
   for (const a of argv) {
+    if (expectingMaxRetries) {
+      if (!/^\d+$/.test(a)) {
+        throw new Error(
+          `--max-retries must be a non-negative integer, got: ${JSON.stringify(a)}`
+        );
+      }
+      maxRetries = Number.parseInt(a, 10);
+      expectingMaxRetries = false;
+      continue;
+    }
     if (a === "-h" || a === "--help") help = true;
     else if (a === "-V" || a === "--version") version = true;
     else if (a === "--print-config") printConfig = true;
     else if (a === "--no-keep-alive") noKeepAlive = true;
+    else if (a === "--max-retries") expectingMaxRetries = true;
     else rest.push(a);
   }
-  return { help, version, printConfig, noKeepAlive, rest };
+  if (expectingMaxRetries) {
+    throw new Error("--max-retries requires a value");
+  }
+  return { help, version, printConfig, noKeepAlive, maxRetries, rest };
 }
 
 /**
@@ -76,6 +94,7 @@ Flags:
   -V, --version       print bin + core version and exit
   --print-config      resolve workspace / docker context / image / docker socket, print, exit without launching docker
   --no-keep-alive     skip OS wake-lock acquisition (default: acquire system-sleep inhibitor for loop lifetime)
+  --max-retries <N>   per-stage retry budget on transient failure (default: 3; 0 disables retries)
 
 Environment variables:
   RALPH_WORKSPACE       host dir bind-mounted at /home/agent/workspace (default: cwd)
@@ -103,6 +122,7 @@ Build fallback runs only if pull fails AND $RALPH_DOCKER_CONTEXT/Dockerfile exis
 export type PrintConfigOptions = {
   cliVersion?: string;
   noKeepAlive?: boolean;
+  maxRetries?: number;
 };
 
 export function printConfig(
@@ -112,7 +132,11 @@ export function printConfig(
   sandcastleDir: string,
   opts: PrintConfigOptions = {}
 ): void {
-  const { cliVersion, noKeepAlive = false } = opts;
+  const {
+    cliVersion,
+    noKeepAlive = false,
+    maxRetries = DEFAULT_MAX_RETRIES,
+  } = opts;
   const dockerfile = resolveDockerfile(ralphDir);
   const dfPresent = existsSync(dockerfile);
   const core = readCoreVersion();
@@ -151,5 +175,6 @@ export function printConfig(
   sandcastleDir         ${sandcastleDir}
   RALPH_DOCKER_SOCK     ${sockStatus}
   keep-alive            ${keepAliveStatus}
+  max-retries           ${maxRetries}
 `);
 }

--- a/packages/core/src/detach.ts
+++ b/packages/core/src/detach.ts
@@ -1,0 +1,87 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, openSync } from "node:fs";
+import { dirname } from "node:path";
+
+export type DetachedChild = Pick<ChildProcess, "pid" | "unref">;
+
+export type DetachSpawner = (
+  command: string,
+  args: readonly string[],
+  options: {
+    detached: boolean;
+    stdio: readonly ["ignore", number, number];
+    windowsHide: boolean;
+  }
+) => DetachedChild;
+
+export type DetachOptions = {
+  /** Absolute path to the log file. stdout + stderr of the child are appended here. */
+  logPath: string;
+  /** The full original argv (from process.argv.slice(2)). --detach and --log are stripped before re-spawn. */
+  argv: string[];
+  /** Path to the bin script the child should run (typically process.argv[1]). */
+  binEntry: string;
+  // Test seams ----------------------------------------------------------
+  execPath?: string;
+  spawnFn?: DetachSpawner;
+  openFd?: (path: string) => number;
+  ensureDir?: (path: string) => void;
+  stderr?: { write: (s: string) => void };
+  exit?: (code?: number) => never;
+};
+
+/**
+ * Strip `--detach` and `--log <value>` from an argv array so the re-spawned
+ * child does not fork again and does not re-interpret the log target.
+ */
+export function stripDetachFlags(argv: readonly string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--detach") continue;
+    if (a === "--log") {
+      i++; // also skip the value
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+}
+
+/**
+ * Fork the current bin into the background, redirect its stdio to `logPath`,
+ * print `detached pid <pid>, log <path>` on stderr, and exit the parent with
+ * code 0. The re-spawned child receives the original argv minus --detach /
+ * --log so it cannot fork again.
+ */
+export function detachAndExit(opts: DetachOptions): never {
+  const execPath = opts.execPath ?? process.execPath;
+  const spawnFn: DetachSpawner =
+    opts.spawnFn ??
+    ((cmd, args, options) =>
+      spawn(cmd, args as string[], {
+        detached: options.detached,
+        stdio: options.stdio as ["ignore", number, number],
+        windowsHide: options.windowsHide,
+      }));
+  const openFd = opts.openFd ?? ((p) => openSync(p, "a"));
+  const ensureDir =
+    opts.ensureDir ?? ((p) => mkdirSync(p, { recursive: true }));
+  const stderr = opts.stderr ?? process.stderr;
+  const exit: (code?: number) => never =
+    opts.exit ?? ((code) => process.exit(code));
+
+  ensureDir(dirname(opts.logPath));
+  const logFd = openFd(opts.logPath);
+
+  const childArgv = stripDetachFlags(opts.argv);
+  const child = spawnFn(execPath, [opts.binEntry, ...childArgv], {
+    detached: true,
+    stdio: ["ignore", logFd, logFd] as const,
+    windowsHide: true,
+  });
+
+  child.unref();
+  stderr.write(`detached pid ${child.pid}, log ${opts.logPath}\n`);
+  exit(0);
+}

--- a/packages/core/src/gh-main.ts
+++ b/packages/core/src/gh-main.ts
@@ -37,7 +37,10 @@ export async function runGhAfk(
   const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
 
   if (flags.printConfig) {
-    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, opts.cliVersion);
+    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
+      cliVersion: opts.cliVersion,
+      noKeepAlive: flags.noKeepAlive,
+    });
     return;
   }
 
@@ -60,5 +63,6 @@ export async function runGhAfk(
     ralphDir,
     workspaceDir,
     sandcastleDir,
+    noKeepAlive: flags.noKeepAlive,
   });
 }

--- a/packages/core/src/gh-main.ts
+++ b/packages/core/src/gh-main.ts
@@ -40,6 +40,7 @@ export async function runGhAfk(
     printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
       cliVersion: opts.cliVersion,
       noKeepAlive: flags.noKeepAlive,
+      maxRetries: flags.maxRetries,
     });
     return;
   }
@@ -64,5 +65,6 @@ export async function runGhAfk(
     workspaceDir,
     sandcastleDir,
     noKeepAlive: flags.noKeepAlive,
+    maxRetries: flags.maxRetries,
   });
 }

--- a/packages/core/src/gh-main.ts
+++ b/packages/core/src/gh-main.ts
@@ -49,6 +49,7 @@ export async function runGhAfk(
       maxRetries: flags.maxRetries,
       detach: flags.detach,
       detachLogPath,
+      notify: flags.notify,
     });
     return;
   }
@@ -82,5 +83,6 @@ export async function runGhAfk(
     sandcastleDir,
     noKeepAlive: flags.noKeepAlive,
     maxRetries: flags.maxRetries,
+    notify: flags.notify,
   });
 }

--- a/packages/core/src/gh-main.ts
+++ b/packages/core/src/gh-main.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -7,6 +7,7 @@ import {
   printHelp,
   printVersion,
 } from "./cli-help.js";
+import { detachAndExit } from "./detach.js";
 import { runLoop } from "./loop.js";
 import { STAGES } from "./stages.js";
 
@@ -36,13 +37,28 @@ export async function runGhAfk(
   const workspaceDir = resolve(process.env.RALPH_WORKSPACE ?? process.cwd());
   const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
 
+  const detachLogPath = flags.detach
+    ? (flags.log ??
+      join(workspaceDir, ".ralph-tmp", "logs", `detached-${process.pid}.log`))
+    : undefined;
+
   if (flags.printConfig) {
     printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
       cliVersion: opts.cliVersion,
       noKeepAlive: flags.noKeepAlive,
       maxRetries: flags.maxRetries,
+      detach: flags.detach,
+      detachLogPath,
     });
     return;
+  }
+
+  if (flags.detach && detachLogPath) {
+    detachAndExit({
+      logPath: detachLogPath,
+      argv,
+      binEntry: process.argv[1],
+    });
   }
 
   const [iterationsArg] = flags.rest;

--- a/packages/core/src/gh-main.ts
+++ b/packages/core/src/gh-main.ts
@@ -53,14 +53,6 @@ export async function runGhAfk(
     return;
   }
 
-  if (flags.detach && detachLogPath) {
-    detachAndExit({
-      logPath: detachLogPath,
-      argv,
-      binEntry: process.argv[1],
-    });
-  }
-
   const [iterationsArg] = flags.rest;
   if (!iterationsArg) {
     console.error(`Usage: ${BIN} ${USAGE}`);
@@ -71,6 +63,14 @@ export async function runGhAfk(
   if (!Number.isFinite(iterations) || iterations < 1) {
     console.error(`Invalid iterations: ${iterationsArg}`);
     process.exit(1);
+  }
+
+  if (flags.detach && detachLogPath) {
+    detachAndExit({
+      logPath: detachLogPath,
+      argv,
+      binEntry: process.argv[1],
+    });
   }
 
   await runLoop({

--- a/packages/core/src/keepalive.ts
+++ b/packages/core/src/keepalive.ts
@@ -1,0 +1,163 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+export type SpawnedChild = Pick<ChildProcess, "kill" | "on" | "pid">;
+
+export type Spawner = (
+  command: string,
+  args: readonly string[],
+  options: { detached?: boolean; stdio?: "ignore" }
+) => SpawnedChild;
+
+export type AcquireOptions = {
+  reason?: string;
+  spawner?: Spawner;
+  platform?: NodeJS.Platform;
+  parentPid?: number;
+  wslHint?: () => boolean;
+  warn?: (msg: string) => void;
+};
+
+export type Releaser = {
+  release: () => void;
+};
+
+const NOOP_RELEASER: Releaser = { release: () => {} };
+
+const DEFAULT_REASON = "ralph-afk loop";
+
+function defaultSpawner(
+  command: string,
+  args: readonly string[],
+  options: { detached?: boolean; stdio?: "ignore" }
+): SpawnedChild {
+  return spawn(command, args as string[], {
+    detached: options.detached ?? false,
+    stdio: options.stdio ?? "ignore",
+    windowsHide: true,
+  });
+}
+
+function defaultWslHint(): boolean {
+  try {
+    if (!existsSync("/proc/version")) return false;
+    return /microsoft/i.test(readFileSync("/proc/version", "utf8"));
+  } catch {
+    return false;
+  }
+}
+
+function defaultWarn(msg: string): void {
+  process.stderr.write(`[keepalive] ${msg}\n`);
+}
+
+/**
+ * Build the powershell argv that holds ES_SYSTEM_REQUIRED for the lifetime of
+ * the spawned child. Killing the child lets the OS clear ES_CONTINUOUS on
+ * process exit (per SetThreadExecutionState docs).
+ */
+function windowsArgs(): { cmd: string; args: string[] } {
+  const script =
+    "Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;" +
+    'public static class P{[DllImport("kernel32.dll")]' +
+    "public static extern uint SetThreadExecutionState(uint e);}';" +
+    "[P]::SetThreadExecutionState(0x80000000 -bor 0x00000001) | Out-Null;" +
+    "while($true){Start-Sleep -Seconds 60}";
+  return {
+    cmd: "powershell",
+    args: ["-NoProfile", "-NonInteractive", "-Command", script],
+  };
+}
+
+function macosArgs(parentPid: number): { cmd: string; args: string[] } {
+  return {
+    cmd: "caffeinate",
+    args: ["-i", "-w", String(parentPid)],
+  };
+}
+
+function linuxArgs(reason: string): { cmd: string; args: string[] } {
+  return {
+    cmd: "systemd-inhibit",
+    args: [
+      "--what=sleep",
+      `--why=${reason}`,
+      "--mode=block",
+      "sleep",
+      "infinity",
+    ],
+  };
+}
+
+/**
+ * Acquire an OS wake-lock for the lifetime of the returned Releaser. Platform
+ * dispatch is per-OS; missing utilities degrade to a no-op (warning emitted
+ * once) so the loop never crashes on a stripped image.
+ */
+export function acquire(opts: AcquireOptions = {}): Releaser {
+  const platform = opts.platform ?? process.platform;
+  const spawner = opts.spawner ?? defaultSpawner;
+  const parentPid = opts.parentPid ?? process.pid;
+  const wslHint = opts.wslHint ?? defaultWslHint;
+  const warn = opts.warn ?? defaultWarn;
+  const reason = opts.reason ?? DEFAULT_REASON;
+
+  if (platform === "linux" && wslHint()) {
+    warn(
+      "WSL2 detected: systemd-inhibit blocks WSL idle only, not Windows host sleep. " +
+        "Configure the Windows power plan to keep the host awake."
+    );
+  }
+
+  let spec: { cmd: string; args: string[] };
+  if (platform === "win32") {
+    spec = windowsArgs();
+  } else if (platform === "darwin") {
+    spec = macosArgs(parentPid);
+  } else if (platform === "linux") {
+    spec = linuxArgs(reason);
+  } else {
+    warn(`unsupported platform ${platform}: skipping wake-lock`);
+    return NOOP_RELEASER;
+  }
+
+  let child: SpawnedChild;
+  try {
+    child = spawner(spec.cmd, spec.args, { stdio: "ignore" });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      warn(`${spec.cmd} not found: continuing without wake-lock`);
+    } else {
+      warn(
+        `failed to spawn ${spec.cmd}: ${(err as Error).message}. Continuing without wake-lock.`
+      );
+    }
+    return NOOP_RELEASER;
+  }
+
+  // Swallow spawn-time errors emitted asynchronously (e.g. ENOENT surfaced on
+  // the child rather than thrown by spawn itself on some platforms).
+  let released = false;
+  child.on("error", (err: NodeJS.ErrnoException) => {
+    if (released) return;
+    released = true;
+    if (err.code === "ENOENT") {
+      warn(`${spec.cmd} not found: continuing without wake-lock`);
+    } else {
+      warn(`wake-lock child error: ${err.message}`);
+    }
+  });
+
+  return {
+    release: () => {
+      if (released) return;
+      released = true;
+      try {
+        child.kill();
+      } catch {
+        // Already dead; ignore.
+      }
+    },
+  };
+}

--- a/packages/core/src/keepalive.ts
+++ b/packages/core/src/keepalive.ts
@@ -148,6 +148,15 @@ export function acquire(opts: AcquireOptions = {}): Releaser {
       warn(`wake-lock child error: ${err.message}`);
     }
   });
+  child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+    if (released) return;
+    released = true;
+    const reason =
+      code == null ? `signal ${signal ?? "unknown"}` : `exit ${code}`;
+    warn(
+      `${spec.cmd} wake-lock exited early (${reason}); continuing without wake-lock`
+    );
+  });
 
   return {
     release: () => {

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -1,5 +1,6 @@
 import { join, posix } from "node:path";
 
+import { acquire, type Releaser } from "./keepalive.js";
 import { renderTemplate } from "./render.js";
 import {
   ensureImage,
@@ -25,50 +26,89 @@ export type LoopOptions = {
   ralphDir: string;
   workspaceDir: string;
   sandcastleDir: string;
+  /** When true, skip OS wake-lock acquisition. Default: false. */
+  noKeepAlive?: boolean;
 };
 
 export async function runLoop(opts: LoopOptions): Promise<void> {
-  const { stages, inputs, iterations, ralphDir, workspaceDir, sandcastleDir } =
-    opts;
+  const {
+    stages,
+    inputs,
+    iterations,
+    ralphDir,
+    workspaceDir,
+    sandcastleDir,
+    noKeepAlive = false,
+  } = opts;
 
   ensureImage(ralphDir);
 
-  for (let i = 1; i <= iterations; i++) {
-    let gateResult = "";
-    for (let s = 0; s < stages.length; s++) {
-      const stage = stages[s];
-      const banner = USE_COLOR
-        ? `${dim("\u2501\u2501\u2501")} ${bold(`iteration ${i}/${iterations}`)} ${dim("\u00b7")} ${bold(stage.name)} ${dim(`(stage ${s + 1}/${stages.length})`)} ${dim("\u2501\u2501\u2501")}`
-        : `== iteration ${i}/${iterations} \u00b7 ${stage.name} (stage ${s + 1}/${stages.length}) ==`;
-      process.stderr.write(`\n${banner}\n`);
-      const templatePath = join(sandcastleDir, "templates", stage.template);
-      const spillRel = `spill-${process.pid}-${i}-${s}-${Date.now()}`;
-      const spillHostDir = join(workspaceDir, ".ralph-tmp", spillRel);
-      const spillRefPath = posix.join(".ralph-tmp", spillRel);
-      const prompt = renderTemplate(
-        templatePath,
-        { INPUTS: inputs },
-        { cwd: workspaceDir, spillHostDir, spillRefPath }
-      );
-      const result = await runStage(
-        stage,
-        prompt,
-        workspaceDir,
-        i,
-        spillHostDir
-      );
-      if (s === 0) {
-        gateResult = result;
-        if (gateResult.includes(SENTINEL)) {
-          const msg =
-            greenOut(SYM_OUT.bullet) +
-            " " +
-            boldOut("Ralph complete") +
-            dimOut(" after " + i + " iterations");
-          process.stdout.write(msg + "\n");
-          return;
+  const releaser: Releaser = noKeepAlive
+    ? { release: () => {} }
+    : acquire({ reason: "ralph-afk loop" });
+
+  // Single release path: signal handlers and the finally below all funnel
+  // through releaseOnce so the wake-lock child is killed exactly once.
+  let released = false;
+  const releaseOnce = (): void => {
+    if (released) return;
+    released = true;
+    releaser.release();
+  };
+
+  const onSigint = (): void => {
+    releaseOnce();
+    process.exit(130);
+  };
+  const onSigterm = (): void => {
+    releaseOnce();
+    process.exit(143);
+  };
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+
+  try {
+    for (let i = 1; i <= iterations; i++) {
+      let gateResult = "";
+      for (let s = 0; s < stages.length; s++) {
+        const stage = stages[s];
+        const banner = USE_COLOR
+          ? `${dim("\u2501\u2501\u2501")} ${bold(`iteration ${i}/${iterations}`)} ${dim("\u00b7")} ${bold(stage.name)} ${dim(`(stage ${s + 1}/${stages.length})`)} ${dim("\u2501\u2501\u2501")}`
+          : `== iteration ${i}/${iterations} \u00b7 ${stage.name} (stage ${s + 1}/${stages.length}) ==`;
+        process.stderr.write(`\n${banner}\n`);
+        const templatePath = join(sandcastleDir, "templates", stage.template);
+        const spillRel = `spill-${process.pid}-${i}-${s}-${Date.now()}`;
+        const spillHostDir = join(workspaceDir, ".ralph-tmp", spillRel);
+        const spillRefPath = posix.join(".ralph-tmp", spillRel);
+        const prompt = renderTemplate(
+          templatePath,
+          { INPUTS: inputs },
+          { cwd: workspaceDir, spillHostDir, spillRefPath }
+        );
+        const result = await runStage(
+          stage,
+          prompt,
+          workspaceDir,
+          i,
+          spillHostDir
+        );
+        if (s === 0) {
+          gateResult = result;
+          if (gateResult.includes(SENTINEL)) {
+            const msg =
+              greenOut(SYM_OUT.bullet) +
+              " " +
+              boldOut("Ralph complete") +
+              dimOut(" after " + i + " iterations");
+            process.stdout.write(msg + "\n");
+            return;
+          }
         }
       }
     }
+  } finally {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+    releaseOnce();
   }
 }

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -1,16 +1,26 @@
-import { join, posix } from "node:path";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join, posix } from "node:path";
 
 import { acquire, type Releaser } from "./keepalive.js";
 import { renderTemplate } from "./render.js";
 import {
+  DEFAULT_BACKOFF_MS,
+  DEFAULT_MAX_RETRIES,
+  backoffFor,
+  withRetries,
+} from "./retry.js";
+import {
   ensureImage,
   runStage,
+  stageLogPath,
   USE_COLOR,
   dim,
   bold,
+  red,
   greenOut,
   boldOut,
   dimOut,
+  SYM,
   SYM_OUT,
 } from "./runner.js";
 import type { Stage } from "./stages.js";
@@ -28,6 +38,8 @@ export type LoopOptions = {
   sandcastleDir: string;
   /** When true, skip OS wake-lock acquisition. Default: false. */
   noKeepAlive?: boolean;
+  /** Per-stage retry budget. Default: 3. Set to 0 to disable retries. */
+  maxRetries?: number;
 };
 
 export async function runLoop(opts: LoopOptions): Promise<void> {
@@ -39,6 +51,7 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     workspaceDir,
     sandcastleDir,
     noKeepAlive = false,
+    maxRetries = DEFAULT_MAX_RETRIES,
   } = opts;
 
   ensureImage(ralphDir);
@@ -69,7 +82,6 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
 
   try {
     for (let i = 1; i <= iterations; i++) {
-      let gateResult = "";
       for (let s = 0; s < stages.length; s++) {
         const stage = stages[s];
         const banner = USE_COLOR
@@ -85,16 +97,40 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
           { INPUTS: inputs },
           { cwd: workspaceDir, spillHostDir, spillRefPath }
         );
-        const result = await runStage(
-          stage,
-          prompt,
-          workspaceDir,
-          i,
-          spillHostDir
-        );
+
+        const stageLog = stageLogPath(workspaceDir, i, stage.name);
+        mkdirSync(dirname(stageLog), { recursive: true });
+
+        let result: string;
+        try {
+          result = await withRetries(
+            () =>
+              runStage(stage, prompt, workspaceDir, i, spillHostDir, stageLog),
+            {
+              max: maxRetries,
+              backoffMs: DEFAULT_BACKOFF_MS,
+              onAttempt: (attempt, err) => {
+                const wait = backoffFor(DEFAULT_BACKOFF_MS, attempt);
+                const marker = `[retry] attempt ${attempt} of ${maxRetries} after ${wait} ms`;
+                process.stderr.write(
+                  `${USE_COLOR ? dim(marker) : marker} ${dim("(" + (err as Error).message + ")")}\n`
+                );
+                try {
+                  appendFileSync(stageLog, marker + "\n");
+                } catch {
+                  // log file may be unwritable; never crash the loop on the marker.
+                }
+              },
+            }
+          );
+        } catch (err) {
+          const msg = `${red(SYM.cross)} ${bold("iteration " + i + " stage " + stage.name + " failed")} after ${maxRetries} retries: ${(err as Error).message}`;
+          process.stderr.write(msg + "\n");
+          break;
+        }
+
         if (s === 0) {
-          gateResult = result;
-          if (gateResult.includes(SENTINEL)) {
+          if (result.includes(SENTINEL)) {
             const msg =
               greenOut(SYM_OUT.bullet) +
               " " +

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -93,7 +93,7 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
   let completedIterations = 0;
   let sentinelHit = false;
   try {
-    ensureImage(ralphDir);
+    await ensureImage(ralphDir, { signal: stageAbort.signal });
 
     for (let i = 1; i <= iterations; i++) {
       for (let s = 0; s < stages.length; s++) {

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -2,6 +2,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join, posix } from "node:path";
 
 import { acquire, type Releaser } from "./keepalive.js";
+import { notifyComplete, notifyError } from "./notify.js";
 import { renderTemplate } from "./render.js";
 import {
   DEFAULT_BACKOFF_MS,
@@ -40,6 +41,8 @@ export type LoopOptions = {
   noKeepAlive?: boolean;
   /** Per-stage retry budget. Default: 3. Set to 0 to disable retries. */
   maxRetries?: number;
+  /** When true, fire OS notification + bell on loop terminal events. Default: false. */
+  notify?: boolean;
 };
 
 export async function runLoop(opts: LoopOptions): Promise<void> {
@@ -52,6 +55,7 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     sandcastleDir,
     noKeepAlive = false,
     maxRetries = DEFAULT_MAX_RETRIES,
+    notify = false,
   } = opts;
 
   ensureImage(ralphDir);
@@ -70,16 +74,20 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
   };
 
   const onSigint = (): void => {
+    if (notify) notifyError("interrupted (SIGINT)");
     releaseOnce();
     process.exit(130);
   };
   const onSigterm = (): void => {
+    if (notify) notifyError("terminated (SIGTERM)");
     releaseOnce();
     process.exit(143);
   };
   process.on("SIGINT", onSigint);
   process.on("SIGTERM", onSigterm);
 
+  let completedIterations = 0;
+  let sentinelHit = false;
   try {
     for (let i = 1; i <= iterations; i++) {
       for (let s = 0; s < stages.length; s++) {
@@ -137,14 +145,23 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
               boldOut("Ralph complete") +
               dimOut(" after " + i + " iterations");
             process.stdout.write(msg + "\n");
+            sentinelHit = true;
+            completedIterations = i;
             return;
           }
         }
       }
+      completedIterations = i;
     }
+  } catch (err) {
+    if (notify) notifyError((err as Error).message);
+    throw err;
   } finally {
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
     releaseOnce();
+    if (notify && (sentinelHit || completedIterations === iterations)) {
+      notifyComplete(completedIterations, sentinelHit);
+    }
   }
 }

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -58,11 +58,10 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     notify = false,
   } = opts;
 
-  ensureImage(ralphDir);
-
   const releaser: Releaser = noKeepAlive
     ? { release: () => {} }
     : acquire({ reason: "ralph-afk loop" });
+  const stageAbort = new AbortController();
 
   // Single release path: signal handlers and the finally below all funnel
   // through releaseOnce so the wake-lock child is killed exactly once.
@@ -72,13 +71,18 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     released = true;
     releaser.release();
   };
+  const abortActiveStage = (): void => {
+    if (!stageAbort.signal.aborted) stageAbort.abort();
+  };
 
   const onSigint = (): void => {
+    abortActiveStage();
     if (notify) notifyError("interrupted (SIGINT)");
     releaseOnce();
     process.exit(130);
   };
   const onSigterm = (): void => {
+    abortActiveStage();
     if (notify) notifyError("terminated (SIGTERM)");
     releaseOnce();
     process.exit(143);
@@ -89,6 +93,8 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
   let completedIterations = 0;
   let sentinelHit = false;
   try {
+    ensureImage(ralphDir);
+
     for (let i = 1; i <= iterations; i++) {
       for (let s = 0; s < stages.length; s++) {
         const stage = stages[s];
@@ -113,7 +119,9 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
         try {
           result = await withRetries(
             () =>
-              runStage(stage, prompt, workspaceDir, i, spillHostDir, stageLog),
+              runStage(stage, prompt, workspaceDir, i, spillHostDir, stageLog, {
+                signal: stageAbort.signal,
+              }),
             {
               max: maxRetries,
               backoffMs: DEFAULT_BACKOFF_MS,
@@ -132,6 +140,12 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
             }
           );
         } catch (err) {
+          const failureMarker = `[failure] iteration ${i} stage ${stage.name} failed after ${maxRetries} retries: ${(err as Error).message}`;
+          try {
+            appendFileSync(stageLog, failureMarker + "\n");
+          } catch {
+            // log file may be unwritable; stderr still carries the failure.
+          }
           const msg = `${red(SYM.cross)} ${bold("iteration " + i + " stage " + stage.name + " failed")} after ${maxRetries} retries: ${(err as Error).message}`;
           process.stderr.write(msg + "\n");
           break;

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -37,7 +37,10 @@ export async function runAfk(
   const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
 
   if (flags.printConfig) {
-    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, opts.cliVersion);
+    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
+      cliVersion: opts.cliVersion,
+      noKeepAlive: flags.noKeepAlive,
+    });
     return;
   }
 
@@ -60,5 +63,6 @@ export async function runAfk(
     ralphDir,
     workspaceDir,
     sandcastleDir,
+    noKeepAlive: flags.noKeepAlive,
   });
 }

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -40,6 +40,7 @@ export async function runAfk(
     printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
       cliVersion: opts.cliVersion,
       noKeepAlive: flags.noKeepAlive,
+      maxRetries: flags.maxRetries,
     });
     return;
   }
@@ -64,5 +65,6 @@ export async function runAfk(
     workspaceDir,
     sandcastleDir,
     noKeepAlive: flags.noKeepAlive,
+    maxRetries: flags.maxRetries,
   });
 }

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -53,14 +53,6 @@ export async function runAfk(
     return;
   }
 
-  if (flags.detach && detachLogPath) {
-    detachAndExit({
-      logPath: detachLogPath,
-      argv,
-      binEntry: process.argv[1],
-    });
-  }
-
   const [planAndPrd, iterationsArg] = flags.rest;
   if (!planAndPrd || !iterationsArg) {
     console.error(`Usage: ${BIN} ${USAGE}`);
@@ -71,6 +63,14 @@ export async function runAfk(
   if (!Number.isFinite(iterations) || iterations < 1) {
     console.error(`Invalid iterations: ${iterationsArg}`);
     process.exit(1);
+  }
+
+  if (flags.detach && detachLogPath) {
+    detachAndExit({
+      logPath: detachLogPath,
+      argv,
+      binEntry: process.argv[1],
+    });
   }
 
   await runLoop({

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -7,6 +7,7 @@ import {
   printHelp,
   printVersion,
 } from "./cli-help.js";
+import { detachAndExit } from "./detach.js";
 import { runLoop } from "./loop.js";
 import { STAGES } from "./stages.js";
 
@@ -36,13 +37,28 @@ export async function runAfk(
   const workspaceDir = resolve(process.env.RALPH_WORKSPACE ?? process.cwd());
   const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
 
+  const detachLogPath = flags.detach
+    ? (flags.log ??
+      join(workspaceDir, ".ralph-tmp", "logs", `detached-${process.pid}.log`))
+    : undefined;
+
   if (flags.printConfig) {
     printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
       cliVersion: opts.cliVersion,
       noKeepAlive: flags.noKeepAlive,
       maxRetries: flags.maxRetries,
+      detach: flags.detach,
+      detachLogPath,
     });
     return;
+  }
+
+  if (flags.detach && detachLogPath) {
+    detachAndExit({
+      logPath: detachLogPath,
+      argv,
+      binEntry: process.argv[1],
+    });
   }
 
   const [planAndPrd, iterationsArg] = flags.rest;

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -49,6 +49,7 @@ export async function runAfk(
       maxRetries: flags.maxRetries,
       detach: flags.detach,
       detachLogPath,
+      notify: flags.notify,
     });
     return;
   }
@@ -82,5 +83,6 @@ export async function runAfk(
     sandcastleDir,
     noKeepAlive: flags.noKeepAlive,
     maxRetries: flags.maxRetries,
+    notify: flags.notify,
   });
 }

--- a/packages/core/src/notify.ts
+++ b/packages/core/src/notify.ts
@@ -1,0 +1,174 @@
+import { spawn, type ChildProcess } from "node:child_process";
+
+export type NotifyLevel = "info" | "error";
+
+export type NotifySpawnedChild = Pick<ChildProcess, "on" | "unref">;
+
+export type NotifySpawner = (
+  command: string,
+  args: readonly string[]
+) => NotifySpawnedChild;
+
+export type NotifyOptions = {
+  title: string;
+  body: string;
+  level: NotifyLevel;
+  /** When false, suppress the terminal bell. Default: true. */
+  sound?: boolean;
+  // Test seams --------------------------------------------------------
+  platform?: NodeJS.Platform;
+  spawner?: NotifySpawner;
+  stderr?: { write: (s: string) => void };
+};
+
+function defaultSpawner(
+  command: string,
+  args: readonly string[]
+): NotifySpawnedChild {
+  return spawn(command, args as string[], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+}
+
+/**
+ * Spawn a fire-and-forget child. Swallows spawn-time + async errors so a
+ * missing utility (ENOENT) never crashes the loop.
+ */
+function fireAndForget(
+  spawner: NotifySpawner,
+  cmd: string,
+  args: string[]
+): boolean {
+  try {
+    const child = spawner(cmd, args);
+    child.on("error", () => {
+      // Async ENOENT (Linux): swallow. The whole point is fire-and-forget.
+    });
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function escSingleQuote(s: string): string {
+  // For AppleScript single-quoted strings via the shell. Replace ' with '\''.
+  return s.replace(/'/g, "'\\''");
+}
+
+function escDoubleQuote(s: string): string {
+  return s.replace(/"/g, '\\"');
+}
+
+function escPsString(s: string): string {
+  // PowerShell single-quoted literal: ' is escaped by doubling.
+  return s.replace(/'/g, "''");
+}
+
+function windowsToast(
+  spawner: NotifySpawner,
+  title: string,
+  body: string
+): boolean {
+  // Try BurntToast first; fall back to msg.exe. Both fire-and-forget; if the
+  // module is missing, the powershell child exits non-zero — we don't observe
+  // it, the caller has already gotten the bell.
+  const psScript =
+    `if (Get-Module -ListAvailable -Name BurntToast) { ` +
+    `Import-Module BurntToast; ` +
+    `New-BurntToastNotification -Text '${escPsString(title)}','${escPsString(body)}' ` +
+    `} else { exit 1 }`;
+  const ok = fireAndForget(spawner, "powershell", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    psScript,
+  ]);
+  if (!ok) return false;
+  // Always also try msg.exe as a secondary path (cheap, mostly a no-op when
+  // BurntToast wins). msg.exe is not on every Windows SKU (Home edition lacks
+  // it) — swallow failure.
+  fireAndForget(spawner, "msg.exe", ["*", `${title}: ${body}`]);
+  return true;
+}
+
+function macosBanner(
+  spawner: NotifySpawner,
+  title: string,
+  body: string,
+  level: NotifyLevel
+): boolean {
+  const sound = level === "info" ? "Glass" : "Basso";
+  const script =
+    `display notification "${escDoubleQuote(body)}" ` +
+    `with title "${escDoubleQuote(title)}" ` +
+    `sound name "${sound}"`;
+  return fireAndForget(spawner, "osascript", ["-e", script]);
+}
+
+function linuxNotifySend(
+  spawner: NotifySpawner,
+  title: string,
+  body: string,
+  level: NotifyLevel
+): boolean {
+  const urgency = level === "error" ? "critical" : "normal";
+  return fireAndForget(spawner, "notify-send", [
+    "--urgency",
+    urgency,
+    title,
+    body,
+  ]);
+}
+
+/**
+ * Fire a best-effort OS notification + terminal bell. Synchronous return;
+ * never blocks on toast delivery, never crashes on a missing utility.
+ *
+ * Bell (\x07) is written to stderr on every call regardless of OS path.
+ * Apostrophes / quotes in `title` / `body` are escaped per-platform so a
+ * `'` in the message doesn't break the shell wrapping.
+ */
+export function notify(opts: NotifyOptions): void {
+  const platform = opts.platform ?? process.platform;
+  const spawner = opts.spawner ?? defaultSpawner;
+  const stderr = opts.stderr ?? process.stderr;
+  const sound = opts.sound ?? true;
+
+  if (sound) {
+    try {
+      stderr.write("\x07");
+    } catch {
+      // never crash on a bell write.
+    }
+  }
+
+  if (platform === "win32") {
+    windowsToast(spawner, opts.title, opts.body);
+  } else if (platform === "darwin") {
+    macosBanner(spawner, opts.title, opts.body, opts.level);
+  } else if (platform === "linux") {
+    linuxNotifySend(spawner, opts.title, opts.body, opts.level);
+  }
+  // unsupported platforms: bell-only, no toast attempt.
+}
+
+export function notifyComplete(iterations: number, sentinel: boolean): void {
+  notify({
+    level: "info",
+    title: "Ralph complete",
+    body: sentinel
+      ? `Sentinel hit after ${iterations} iteration${iterations === 1 ? "" : "s"}.`
+      : `Reached iteration cap (${iterations}).`,
+  });
+}
+
+export function notifyError(message: string): void {
+  notify({
+    level: "error",
+    title: "Ralph failed",
+    body: message,
+  });
+}

--- a/packages/core/src/notify.ts
+++ b/packages/core/src/notify.ts
@@ -53,11 +53,6 @@ function fireAndForget(
   }
 }
 
-function escSingleQuote(s: string): string {
-  // For AppleScript single-quoted strings via the shell. Replace ' with '\''.
-  return s.replace(/'/g, "'\\''");
-}
-
 function escDoubleQuote(s: string): string {
   return s.replace(/"/g, '\\"');
 }

--- a/packages/core/src/notify.ts
+++ b/packages/core/src/notify.ts
@@ -54,7 +54,7 @@ function fireAndForget(
 }
 
 function escDoubleQuote(s: string): string {
-  return s.replace(/"/g, '\\"');
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
 function escPsString(s: string): string {

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -1,0 +1,49 @@
+export type WithRetriesOptions = {
+  /** Maximum retries after the initial attempt. Total calls = max + 1. */
+  max: number;
+  /** Wait between attempts. backoffMs[i] is the wait before attempt i+1.
+   *  When attempts exceed array length, the last value is reused. */
+  backoffMs: readonly number[];
+  /** Fires after each failed attempt, before the wait. */
+  onAttempt?: (attempt: number, err: unknown) => void;
+  /** Injected for tests so no real wall-clock waits occur. */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+export const DEFAULT_BACKOFF_MS: readonly number[] = [5_000, 30_000, 120_000];
+export const DEFAULT_MAX_RETRIES = 3;
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+export async function withRetries<T>(
+  fn: () => Promise<T>,
+  opts: WithRetriesOptions
+): Promise<T> {
+  const sleep = opts.sleep ?? defaultSleep;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= opts.max; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt === opts.max) break;
+      opts.onAttempt?.(attempt + 1, err);
+      const backoff =
+        opts.backoffMs[attempt] ??
+        opts.backoffMs[opts.backoffMs.length - 1] ??
+        0;
+      await sleep(backoff);
+    }
+  }
+  throw lastErr;
+}
+
+/** Wait that withRetries will impose before the Nth retry (1-indexed). */
+export function backoffFor(
+  backoffMs: readonly number[],
+  attempt: number
+): number {
+  return backoffMs[attempt - 1] ?? backoffMs[backoffMs.length - 1] ?? 0;
+}

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -14,6 +14,10 @@ import { join, posix } from "node:path";
 
 import type { Stage } from "./stages.js";
 
+export type RunStageOptions = {
+  signal?: AbortSignal;
+};
+
 export const IMAGE_REF =
   process.env.RALPH_IMAGE ??
   process.env.RALPH_IMAGE_TAG ?? // legacy
@@ -298,7 +302,8 @@ export async function runStage(
   workspaceDir: string,
   iteration: number,
   spillHostDir?: string,
-  logPathOverride?: string
+  logPathOverride?: string,
+  options: RunStageOptions = {}
 ): Promise<string> {
   const tmpHostDir = join(workspaceDir, ".ralph-tmp");
   mkdirSync(tmpHostDir, { recursive: true });
@@ -367,14 +372,28 @@ export async function runStage(
       `Read the full instructions from the file ./${promptContainerPath} in the current workspace and execute them.`
     );
 
-    return await streamDocker(args, logPath);
+    return await streamDocker(args, logPath, options);
   } finally {
     rmSync(promptHostPath, { force: true });
     if (spillHostDir) rmSync(spillHostDir, { recursive: true, force: true });
   }
 }
 
-function streamDocker(args: string[], logPath: string): Promise<string> {
+function abortError(): Error {
+  const err = new Error("docker run aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+function streamDocker(
+  args: string[],
+  logPath: string,
+  options: RunStageOptions = {}
+): Promise<string> {
+  if (options.signal?.aborted) {
+    return Promise.reject(abortError());
+  }
+
   return new Promise((resolve, reject) => {
     const logFd = openSync(logPath, "a");
     const toolMap = new Map<string, ToolTrack>();
@@ -385,9 +404,48 @@ function streamDocker(args: string[], logPath: string): Promise<string> {
 
     let finalResult = "";
     const stderrTail: string[] = [];
+    let settled = false;
+    let onAbort = (): void => {};
+    let rl: ReturnType<typeof createInterface> | undefined;
+    let rlErr: ReturnType<typeof createInterface> | undefined;
 
-    const rl = createInterface({ input: child.stdout });
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      options.signal?.removeEventListener("abort", onAbort);
+      try {
+        rl?.close();
+      } catch {
+        // Already closed.
+      }
+      try {
+        rlErr?.close();
+      } catch {
+        // Already closed.
+      }
+      try {
+        closeSync(logFd);
+      } catch {
+        // Already closed.
+      }
+      fn();
+    };
+
+    const rejectOnce = (err: unknown): void => finish(() => reject(err));
+    const resolveOnce = (value: string): void => finish(() => resolve(value));
+
+    onAbort = (): void => {
+      try {
+        child.kill();
+      } catch {
+        // Already dead; close handling below will settle if needed.
+      }
+      rejectOnce(abortError());
+    };
+
+    rl = createInterface({ input: child.stdout });
     rl.on("line", (line) => {
+      if (settled) return;
       if (!line.startsWith("{")) return;
 
       appendFileSync(logFd, line + "\n");
@@ -405,26 +463,31 @@ function streamDocker(args: string[], logPath: string): Promise<string> {
       }
     });
 
-    const rlErr = createInterface({ input: child.stderr });
+    rlErr = createInterface({ input: child.stderr });
     rlErr.on("line", (line) => {
+      if (settled) return;
       stderrTail.push(line);
       if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
       process.stderr.write(`${dim("docker  " + line)}\n`);
     });
 
+    if (options.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
     child.on("error", (err) => {
-      closeSync(logFd);
-      reject(err);
+      rejectOnce(err);
     });
     child.on("close", (code) => {
-      closeSync(logFd);
       if (code !== 0) {
-        reject(
+        rejectOnce(
           new Error(`docker run exited with ${code}\n${stderrTail.join("\n")}`)
         );
         return;
       }
-      resolve(finalResult);
+      resolveOnce(finalResult);
     });
   });
 }

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -278,23 +278,35 @@ export function ensureImage(buildContext?: string): void {
   }
 }
 
+export function stageLogPath(
+  workspaceDir: string,
+  iteration: number,
+  stageName: string
+): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return join(
+    workspaceDir,
+    ".ralph-tmp",
+    "logs",
+    `${timestamp}-iter${iteration}-${stageName}.ndjson`
+  );
+}
+
 export async function runStage(
   stage: Stage,
   renderedPrompt: string,
   workspaceDir: string,
   iteration: number,
-  spillHostDir?: string
+  spillHostDir?: string,
+  logPathOverride?: string
 ): Promise<string> {
   const tmpHostDir = join(workspaceDir, ".ralph-tmp");
   mkdirSync(tmpHostDir, { recursive: true });
 
   const logsDir = join(tmpHostDir, "logs");
   mkdirSync(logsDir, { recursive: true });
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const logPath = join(
-    logsDir,
-    `${timestamp}-iter${iteration}-${stage.name}.ndjson`
-  );
+  const logPath =
+    logPathOverride ?? stageLogPath(workspaceDir, iteration, stage.name);
 
   const promptName = `.run-${process.pid}-${iteration}-${Date.now()}.md`;
   const promptHostPath = join(tmpHostDir, promptName);

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -235,7 +235,61 @@ export function isFloatingRef(ref: string): boolean {
   return namePart.slice(colon + 1) === "latest";
 }
 
-export function ensureImage(buildContext?: string): void {
+function abortError(): Error {
+  const err = new Error("docker command aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+type DockerCommandOptions = {
+  signal?: AbortSignal;
+  stdio: "ignore" | "inherit";
+};
+
+function runDockerCommand(
+  args: string[],
+  options: DockerCommandOptions
+): Promise<number | null> {
+  if (options.signal?.aborted) {
+    return Promise.reject(abortError());
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("docker", args, { stdio: options.stdio });
+    let settled = false;
+    let onAbort = (): void => {};
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      options.signal?.removeEventListener("abort", onAbort);
+      fn();
+    };
+    const rejectOnce = (err: unknown): void => finish(() => reject(err));
+    const resolveOnce = (code: number | null): void =>
+      finish(() => resolve(code));
+
+    onAbort = (): void => {
+      try {
+        child.kill();
+      } catch {
+        // Already dead; close/error handling will settle if needed.
+      }
+      rejectOnce(abortError());
+    };
+
+    if (options.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    child.on("error", rejectOnce);
+    child.on("close", resolveOnce);
+  });
+}
+
+function ensureImageSync(buildContext?: string): void {
   const floating = isFloatingRef(IMAGE_REF);
   const hasLocal =
     spawnSync("docker", ["image", "inspect", IMAGE_REF], { stdio: "ignore" })
@@ -280,6 +334,74 @@ export function ensureImage(buildContext?: string): void {
   if (build.status !== 0) {
     throw new Error(`docker build failed (exit ${build.status})`);
   }
+}
+
+async function ensureImageAsync(
+  buildContext: string | undefined,
+  options: RunStageOptions
+): Promise<void> {
+  const floating = isFloatingRef(IMAGE_REF);
+  const hasLocal =
+    (await runDockerCommand(["image", "inspect", IMAGE_REF], {
+      stdio: "ignore",
+      signal: options.signal,
+    })) === 0;
+
+  if (hasLocal && !floating) return;
+
+  process.stderr.write(`${dim("pulling")} ${IMAGE_REF}\n`);
+  const pullStatus = await runDockerCommand(["pull", IMAGE_REF], {
+    stdio: "inherit",
+    signal: options.signal,
+  });
+  if (pullStatus === 0) return;
+
+  if (hasLocal) {
+    process.stderr.write(
+      `${dim("pull failed; using cached local copy of")} ${IMAGE_REF}\n`
+    );
+    return;
+  }
+
+  if (!buildContext) {
+    throw new Error(
+      `docker pull failed for ${IMAGE_REF} and no build context provided. ` +
+        `Set RALPH_DOCKER_CONTEXT to a directory containing a Dockerfile, ` +
+        `or override RALPH_IMAGE to an image you can pull.`
+    );
+  }
+  const dockerfile = resolveDockerfile(buildContext);
+  if (!existsSync(dockerfile)) {
+    throw new Error(
+      `docker pull failed for ${IMAGE_REF} and no Dockerfile at ${dockerfile}`
+    );
+  }
+  process.stderr.write(
+    `${dim("pull failed; building")} ${IMAGE_REF} ${dim("from")} ${buildContext}\n`
+  );
+  const buildStatus = await runDockerCommand(
+    ["build", "-t", IMAGE_REF, "-f", dockerfile, buildContext],
+    {
+      stdio: "inherit",
+      signal: options.signal,
+    }
+  );
+  if (buildStatus !== 0) {
+    throw new Error(`docker build failed (exit ${buildStatus})`);
+  }
+}
+
+export function ensureImage(buildContext?: string): void;
+export function ensureImage(
+  buildContext: string | undefined,
+  options: RunStageOptions
+): Promise<void>;
+export function ensureImage(
+  buildContext?: string,
+  options?: RunStageOptions
+): void | Promise<void> {
+  if (options) return ensureImageAsync(buildContext, options);
+  return ensureImageSync(buildContext);
 }
 
 export function stageLogPath(
@@ -377,12 +499,6 @@ export async function runStage(
     rmSync(promptHostPath, { force: true });
     if (spillHostDir) rmSync(spillHostDir, { recursive: true, force: true });
   }
-}
-
-function abortError(): Error {
-  const err = new Error("docker run aborted");
-  err.name = "AbortError";
-  return err;
 }
 
 function streamDocker(

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "./src",
     "composite": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,13 +29,276 @@ importers:
         specifier: workspace:^
         version: link:../../packages/core
 
-  packages/core: {}
+  packages/core:
+    devDependencies:
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@22.19.19)(vite@8.0.14(@types/node@22.19.19)(yaml@2.9.0))
 
 packages:
+  "@emnapi/core@1.10.0":
+    resolution:
+      {
+        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
+      }
+
+  "@emnapi/runtime@1.10.0":
+    resolution:
+      {
+        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
+      }
+
+  "@emnapi/wasi-threads@1.2.1":
+    resolution:
+      {
+        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
+      }
+
+  "@jridgewell/sourcemap-codec@1.5.5":
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
+
+  "@napi-rs/wasm-runtime@1.1.4":
+    resolution:
+      {
+        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
+      }
+    peerDependencies:
+      "@emnapi/core": ^1.7.1
+      "@emnapi/runtime": ^1.7.1
+
+  "@oxc-project/types@0.132.0":
+    resolution:
+      {
+        integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==,
+      }
+
+  "@rolldown/binding-android-arm64@1.0.2":
+    resolution:
+      {
+        integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@rolldown/binding-darwin-arm64@1.0.2":
+    resolution:
+      {
+        integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@rolldown/binding-darwin-x64@1.0.2":
+    resolution:
+      {
+        integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@rolldown/binding-freebsd-x64@1.0.2":
+    resolution:
+      {
+        integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.2":
+    resolution:
+      {
+        integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.2":
+    resolution:
+      {
+        integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@rolldown/binding-linux-arm64-musl@1.0.2":
+    resolution:
+      {
+        integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+
+  "@rolldown/binding-linux-ppc64-gnu@1.0.2":
+    resolution:
+      {
+        integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.2":
+    resolution:
+      {
+        integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+
+  "@rolldown/binding-linux-x64-gnu@1.0.2":
+    resolution:
+      {
+        integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@rolldown/binding-linux-x64-musl@1.0.2":
+    resolution:
+      {
+        integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+
+  "@rolldown/binding-openharmony-arm64@1.0.2":
+    resolution:
+      {
+        integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@rolldown/binding-wasm32-wasi@1.0.2":
+    resolution:
+      {
+        integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@rolldown/binding-win32-arm64-msvc@1.0.2":
+    resolution:
+      {
+        integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@rolldown/binding-win32-x64-msvc@1.0.2":
+    resolution:
+      {
+        integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@rolldown/pluginutils@1.0.1":
+    resolution:
+      {
+        integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
+      }
+
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+
+  "@tybys/wasm-util@0.10.2":
+    resolution:
+      {
+        integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
+      }
+
+  "@types/chai@5.2.3":
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
+
+  "@types/deep-eql@4.0.2":
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+      }
+
+  "@types/estree@1.0.9":
+    resolution:
+      {
+        integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
+      }
+
   "@types/node@22.19.19":
     resolution:
       {
         integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==,
+      }
+
+  "@vitest/expect@4.1.7":
+    resolution:
+      {
+        integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==,
+      }
+
+  "@vitest/mocker@4.1.7":
+    resolution:
+      {
+        integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==,
+      }
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  "@vitest/pretty-format@4.1.7":
+    resolution:
+      {
+        integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==,
+      }
+
+  "@vitest/runner@4.1.7":
+    resolution:
+      {
+        integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==,
+      }
+
+  "@vitest/snapshot@4.1.7":
+    resolution:
+      {
+        integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==,
+      }
+
+  "@vitest/spy@4.1.7":
+    resolution:
+      {
+        integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==,
+      }
+
+  "@vitest/utils@4.1.7":
+    resolution:
+      {
+        integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==,
       }
 
   ansi-escapes@7.3.0:
@@ -59,6 +322,20 @@ packages:
       }
     engines: { node: ">=12" }
 
+  assertion-error@2.0.1:
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: ">=12" }
+
+  chai@6.2.2:
+    resolution:
+      {
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+      }
+    engines: { node: ">=18" }
+
   cli-cursor@5.0.0:
     resolution:
       {
@@ -73,6 +350,19 @@ packages:
       }
     engines: { node: ">=20" }
 
+  convert-source-map@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
+
+  detect-libc@2.1.2:
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: ">=8" }
+
   emoji-regex@10.6.0:
     resolution:
       {
@@ -86,11 +376,50 @@ packages:
       }
     engines: { node: ">=18" }
 
+  es-module-lexer@2.1.0:
+    resolution:
+      {
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+      }
+
+  estree-walker@3.0.3:
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
+
   eventemitter3@5.0.4:
     resolution:
       {
         integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
       }
+
+  expect-type@1.3.0:
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  fdir@6.5.0:
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: ">=12.0.0" }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
 
   get-east-asian-width@1.6.0:
     resolution:
@@ -114,6 +443,112 @@ packages:
       }
     engines: { node: ">=18" }
 
+  lightningcss-android-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution:
+      {
+        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution:
+      {
+        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+
   lint-staged@17.0.5:
     resolution:
       {
@@ -136,12 +571,32 @@ packages:
       }
     engines: { node: ">=18" }
 
+  magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+
   mimic-function@5.0.1:
     resolution:
       {
         integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
       }
     engines: { node: ">=18" }
+
+  nanoid@3.3.12:
+    resolution:
+      {
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
+  obug@2.1.1:
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
 
   onetime@7.0.0:
     resolution:
@@ -150,12 +605,31 @@ packages:
       }
     engines: { node: ">=18" }
 
+  pathe@2.0.3:
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
+  picocolors@1.1.1:
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
+
   picomatch@4.0.4:
     resolution:
       {
         integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
+
+  postcss@8.5.15:
+    resolution:
+      {
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   prettier@3.8.3:
     resolution:
@@ -178,6 +652,20 @@ packages:
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
 
+  rolldown@1.0.2:
+    resolution:
+      {
+        integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
+
   signal-exit@4.1.0:
     resolution:
       {
@@ -198,6 +686,25 @@ packages:
         integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
       }
     engines: { node: ">=20" }
+
+  source-map-js@1.2.1:
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  stackback@0.0.2:
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
+
+  std-env@4.1.0:
+    resolution:
+      {
+        integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
+      }
 
   string-argv@0.3.2:
     resolution:
@@ -227,12 +734,38 @@ packages:
       }
     engines: { node: ">=12" }
 
+  tinybench@2.9.0:
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
+
   tinyexec@1.1.2:
     resolution:
       {
         integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==,
       }
     engines: { node: ">=18" }
+
+  tinyglobby@0.2.16:
+    resolution:
+      {
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  tinyrainbow@3.1.0:
+    resolution:
+      {
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+      }
+    engines: { node: ">=14.0.0" }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   typescript@5.9.3:
     resolution:
@@ -247,6 +780,104 @@ packages:
       {
         integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
       }
+
+  vite@8.0.14:
+    resolution:
+      {
+        integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    hasBin: true
+    peerDependencies:
+      "@types/node": ^20.19.0 || >=22.12.0
+      "@vitejs/devtools": ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: ">=1.21.0"
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
+      "@vitejs/devtools":
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution:
+      {
+        integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@edge-runtime/vm": "*"
+      "@opentelemetry/api": ^1.9.0
+      "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+      "@vitest/browser-playwright": 4.1.7
+      "@vitest/browser-preview": 4.1.7
+      "@vitest/browser-webdriverio": 4.1.7
+      "@vitest/coverage-istanbul": 4.1.7
+      "@vitest/coverage-v8": 4.1.7
+      "@vitest/ui": 4.1.7
+      happy-dom: "*"
+      jsdom: "*"
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      "@edge-runtime/vm":
+        optional: true
+      "@opentelemetry/api":
+        optional: true
+      "@types/node":
+        optional: true
+      "@vitest/browser-playwright":
+        optional: true
+      "@vitest/browser-preview":
+        optional: true
+      "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/coverage-istanbul":
+        optional: true
+      "@vitest/coverage-v8":
+        optional: true
+      "@vitest/ui":
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: ">=8" }
+    hasBin: true
 
   wrap-ansi@10.0.0:
     resolution:
@@ -271,9 +902,144 @@ packages:
     hasBin: true
 
 snapshots:
+  "@emnapi/core@1.10.0":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.10.0":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/wasi-threads@1.2.1":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@jridgewell/sourcemap-codec@1.5.5": {}
+
+  "@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@tybys/wasm-util": 0.10.2
+    optional: true
+
+  "@oxc-project/types@0.132.0": {}
+
+  "@rolldown/binding-android-arm64@1.0.2":
+    optional: true
+
+  "@rolldown/binding-darwin-arm64@1.0.2":
+    optional: true
+
+  "@rolldown/binding-darwin-x64@1.0.2":
+    optional: true
+
+  "@rolldown/binding-freebsd-x64@1.0.2":
+    optional: true
+
+  "@rolldown/binding-linux-arm-gnueabihf@1.0.2":
+    optional: true
+
+  "@rolldown/binding-linux-arm64-gnu@1.0.2":
+    optional: true
+
+  "@rolldown/binding-linux-arm64-musl@1.0.2":
+    optional: true
+
+  "@rolldown/binding-linux-ppc64-gnu@1.0.2":
+    optional: true
+
+  "@rolldown/binding-linux-s390x-gnu@1.0.2":
+    optional: true
+
+  "@rolldown/binding-linux-x64-gnu@1.0.2":
+    optional: true
+
+  "@rolldown/binding-linux-x64-musl@1.0.2":
+    optional: true
+
+  "@rolldown/binding-openharmony-arm64@1.0.2":
+    optional: true
+
+  "@rolldown/binding-wasm32-wasi@1.0.2":
+    dependencies:
+      "@emnapi/core": 1.10.0
+      "@emnapi/runtime": 1.10.0
+      "@napi-rs/wasm-runtime": 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  "@rolldown/binding-win32-arm64-msvc@1.0.2":
+    optional: true
+
+  "@rolldown/binding-win32-x64-msvc@1.0.2":
+    optional: true
+
+  "@rolldown/pluginutils@1.0.1": {}
+
+  "@standard-schema/spec@1.1.0": {}
+
+  "@tybys/wasm-util@0.10.2":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@types/chai@5.2.3":
+    dependencies:
+      "@types/deep-eql": 4.0.2
+      assertion-error: 2.0.1
+
+  "@types/deep-eql@4.0.2": {}
+
+  "@types/estree@1.0.9": {}
+
   "@types/node@22.19.19":
     dependencies:
       undici-types: 6.21.0
+
+  "@vitest/expect@4.1.7":
+    dependencies:
+      "@standard-schema/spec": 1.1.0
+      "@types/chai": 5.2.3
+      "@vitest/spy": 4.1.7
+      "@vitest/utils": 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  "@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(yaml@2.9.0))":
+    dependencies:
+      "@vitest/spy": 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@22.19.19)(yaml@2.9.0)
+
+  "@vitest/pretty-format@4.1.7":
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  "@vitest/runner@4.1.7":
+    dependencies:
+      "@vitest/utils": 4.1.7
+      pathe: 2.0.3
+
+  "@vitest/snapshot@4.1.7":
+    dependencies:
+      "@vitest/pretty-format": 4.1.7
+      "@vitest/utils": 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  "@vitest/spy@4.1.7": {}
+
+  "@vitest/utils@4.1.7":
+    dependencies:
+      "@vitest/pretty-format": 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -282,6 +1048,10 @@ snapshots:
   ansi-regex@6.2.2: {}
 
   ansi-styles@6.2.3: {}
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -292,11 +1062,30 @@ snapshots:
       slice-ansi: 8.0.0
       string-width: 8.2.1
 
+  convert-source-map@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
   emoji-regex@10.6.0: {}
 
   environment@1.1.0: {}
 
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      "@types/estree": 1.0.9
+
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
 
   get-east-asian-width@1.6.0: {}
 
@@ -305,6 +1094,55 @@ snapshots:
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.6.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lint-staged@17.0.5:
     dependencies:
@@ -331,13 +1169,31 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  magic-string@0.30.21:
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.5
+
   mimic-function@5.0.1: {}
+
+  nanoid@3.3.12: {}
+
+  obug@2.1.1: {}
 
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
 
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
   picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prettier@3.8.3: {}
 
@@ -347,6 +1203,29 @@ snapshots:
       signal-exit: 4.1.0
 
   rfdc@1.4.1: {}
+
+  rolldown@1.0.2:
+    dependencies:
+      "@oxc-project/types": 0.132.0
+      "@rolldown/pluginutils": 1.0.1
+    optionalDependencies:
+      "@rolldown/binding-android-arm64": 1.0.2
+      "@rolldown/binding-darwin-arm64": 1.0.2
+      "@rolldown/binding-darwin-x64": 1.0.2
+      "@rolldown/binding-freebsd-x64": 1.0.2
+      "@rolldown/binding-linux-arm-gnueabihf": 1.0.2
+      "@rolldown/binding-linux-arm64-gnu": 1.0.2
+      "@rolldown/binding-linux-arm64-musl": 1.0.2
+      "@rolldown/binding-linux-ppc64-gnu": 1.0.2
+      "@rolldown/binding-linux-s390x-gnu": 1.0.2
+      "@rolldown/binding-linux-x64-gnu": 1.0.2
+      "@rolldown/binding-linux-x64-musl": 1.0.2
+      "@rolldown/binding-openharmony-arm64": 1.0.2
+      "@rolldown/binding-wasm32-wasi": 1.0.2
+      "@rolldown/binding-win32-arm64-msvc": 1.0.2
+      "@rolldown/binding-win32-x64-msvc": 1.0.2
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -359,6 +1238,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-argv@0.3.2: {}
 
@@ -377,11 +1262,67 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1:
+    optional: true
 
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  vite@8.0.14(@types/node@22.19.19)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      "@types/node": 22.19.19
+      fsevents: 2.3.3
+      yaml: 2.9.0
+
+  vitest@4.1.7(@types/node@22.19.19)(vite@8.0.14(@types/node@22.19.19)(yaml@2.9.0)):
+    dependencies:
+      "@vitest/expect": 4.1.7
+      "@vitest/mocker": 4.1.7(vite@8.0.14(@types/node@22.19.19)(yaml@2.9.0))
+      "@vitest/pretty-format": 4.1.7
+      "@vitest/runner": 4.1.7
+      "@vitest/snapshot": 4.1.7
+      "@vitest/spy": 4.1.7
+      "@vitest/utils": 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@22.19.19)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      "@types/node": 22.19.19
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@10.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #17.

- Add default-on AFK wake-lock support, signal cleanup, retry/backoff handling, detach mode, and completion/failure notifications.
- Wire the new flags through both `ralph-afk` and `ralph-ghafk`, including `--no-keep-alive`, `--max-retries`, `--detach`, `--log`, `--notify`, and expanded `--print-config` output.
- Add focused Vitest coverage for keepalive, retry, detach, and notify behavior, plus updated AFK documentation.

## Verification

- `pnpm --filter @daonhan/ralph-core test`
- `pnpm -r run typecheck`
- `pnpm -r run build`
- `git diff --check origin/main...HEAD`