### PR TITLE
Prepare OSS release and refactor AFK stage pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Something in Ralph (the loop, runner, renderer, or a bin) misbehaves
+title: "bug: "
+labels: bug
+---
+
+## What happened
+
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected vs actual
+
+## Environment
+
+- OS / shell (e.g. Windows PowerShell, macOS, WSL Ubuntu, Linux):
+- `ralph-afk --version` (bin + core):
+- Docker version:
+- Invocation (`ralph-afk` / `ralph-ghafk`, flags, env vars):
+
+## `--print-config` output
+
+<!-- Paste `ralph-afk --print-config` (redact paths if needed). -->
+
+## Logs
+
+<!-- Relevant lines from `.ralph-tmp/logs/*.ndjson` or the detached log. Redact secrets. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/daonhan/ralph/security/advisories/new
+    about: Please report security issues privately, not as a public issue. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an enhancement to Ralph
+title: "feat: "
+labels: enhancement
+---
+
+## Problem / motivation
+
+<!-- What are you trying to do that Ralph doesn't support today? -->
+
+## Proposed solution
+
+<!-- What you'd like to see. New flag? New stage? Template change? -->
+
+## Alternatives considered
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing to Ralph! A few notes:
+- Commits use Conventional Commits (the type + path drive release-please). See RELEASING.md §3.
+- Run the local verify before pushing (see below). CI runs the same on every PR.
+-->
+
+## What & why
+
+<!-- What does this change and why? Link any issue: Closes #NNN -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor / clean-up (no behavior change)
+- [ ] Docs
+- [ ] CI / build / release
+
+## Verification
+
+- [ ] `pnpm -r build`
+- [ ] `pnpm -r typecheck`
+- [ ] `pnpm -r test`
+- [ ] `pnpm test` (root `node --test`)
+- [ ] Smoke scripts where relevant (`node scripts/smoke-templates.mjs`, `smoke-render.mjs`)
+
+## Notes for reviewers
+
+<!-- Anything that needs extra eyes: behavior changes, template/playbook edits, security-relevant surfaces. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # npm dependencies across the pnpm workspace.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  # GitHub Actions used by the CI / publish / release workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# Pre-merge verification gate. Runs the full local-verify sequence
+# (build → typecheck → tests → offline smoke checks) on every PR and on
+# pushes to main. The publish-* workflows only fire on release tags, so this
+# is the only thing that catches regressions before they land.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # The .mjs smoke scripts import from packages/core/dist, so build first.
+      - run: pnpm -r build
+
+      - run: pnpm -r typecheck
+
+      - run: pnpm -r test
+
+      - name: Root contract tests (node --test over scripts/*.test.mjs)
+        run: pnpm test
+
+      - name: Offline smoke checks (renderer + templates + spill)
+        run: |
+          node scripts/smoke-render.mjs
+          node scripts/smoke-templates.mjs
+          node scripts/smoke-spill-size.mjs
+          node scripts/smoke-spill-large.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 .ralph-tmp/
 .ghafk-prompt-*.md
 .pnpm-store/
+.ralph-*.mjs
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ CI in `.github/workflows/publish-image.yml` builds + pushes a single-arch `linux
 
 The core library is ~12 source files in `packages/core/src/` (plus a `__tests__/` vitest suite). Read the loop spine in order to understand the system:
 
-1. **`main.ts` / `gh-main.ts`** — bin entrypoints. Both parse flags via `cli-help.ts`, resolve `workspaceDir` / `ralphDir` / `sandcastleDir` from env vars, then call `runLoop` with a different stage chain.
+1. **`main.ts` / `gh-main.ts`** — thin bin entrypoints. Each just calls `runBin` (`run-bin.ts`) with its stage chain + a `takesInputArg` flag. `runBin` parses flags via `cli-help.ts`, resolves `workspaceDir` / `ralphDir` / `packageDir` from env vars, then calls `runLoop`.
 2. **`loop.ts`** (`runLoop`) — drives the iteration. For each iteration, walks the stage chain. **First stage is the gate**: its `result` string is sentinel-checked for `<promise>NO MORE TASKS</promise>` and the loop exits early on hit. Subsequent stages always run after a non-sentinel gate. Calls `ensureImage` once before the loop.
 3. **`render.ts`** (`renderTemplate`) — expands the five template tags below before each stage runs. Synchronous, uses host `execSync` for shell tags.
 4. **`runner.ts`** (`ensureImage`, `runStage`) — docker plumbing.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**daonhan@gmail.com**. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,14 +194,20 @@ await runLoop({
 
 The agent playbooks are plain Markdown:
 
+- [`packages/core/templates/playbook-common.md`](./packages/core/templates/playbook-common.md)
+  — the **shared** body: task-priority ladder, feedback loops (incl. the dotnet MSB3248
+  workaround), commit rules, final rules. Injected into **both** loops.
 - [`packages/core/templates/prompt.md`](./packages/core/templates/prompt.md) — the
-  `ralph-afk` (plan/PRD) playbook.
-- [`packages/core/templates/ghprompt.md`](./packages/core/templates/ghprompt.md) —
-  the `ralph-ghafk` (GitHub-issue) playbook.
+  `ralph-afk` (plan/PRD) **header**: where the work comes from (`<inputs>`) + progress recording.
+- [`packages/core/templates/ghprompt.md`](./packages/core/templates/ghprompt.md) — the
+  `ralph-ghafk` (GitHub-issue) **header**: issue triage + close/comment the issue.
 
-The iteration templates `afk.md` / `ghafk.md` / `review.md` pull the playbooks in
-with the `@include:` tag — edit the playbook, not the wrapper, to change task
-priority or feedback loops. After editing a template, run `node
+The iteration templates `afk.md` / `ghafk.md` each `@include` their bespoke header **and**
+`playbook-common.md`; `review.md` is standalone. Edit `playbook-common.md` to change task
+priority or feedback loops for both loops; edit a header for loop-specific behavior. The
+renderer's `@include` is single-pass (a file pulled in by `@include` is not re-scanned for
+further `@include`s), so both includes live at the top level of `afk.md` / `ghafk.md` — don't
+nest an `@include` inside `prompt.md` / `ghprompt.md`. After editing, run `node
 scripts/smoke-templates.mjs` to confirm it still renders.
 
 ## Smoke-test published artifacts
@@ -274,3 +280,9 @@ overrides, the rollback runbook, and the compatibility matrix.
 - **Conventional-commit messages drive release-please.** The commit type sets the
   bump and CHANGELOG section, and the path decides the component — see
   [`./RELEASING.md`](./RELEASING.md) section 3.
+- **Template shell tags must stay static.** The `` !`cmd` ``, `` !?`cmd` ``, and
+  `@spill` tags run their command body on the **host shell**. Only ever put static
+  command strings in a tag body — never interpolate runtime or untrusted data (INPUTS,
+  issue/commit text, branch names) into one. `{{ INPUTS }}` is substituted last and is
+  read by the agent inside the container, never re-shelled on the host. Breaking this
+  invariant is direct host RCE — see [`./SECURITY.md`](./SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Paul Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,6 +4,8 @@ Zero-to-first-loop for a brand-new user who just wants to run Ralph against thei
 
 Ralph drives [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) against your repo in an iterating implementer → reviewer loop, isolated inside an ephemeral Docker sandbox.
 
+> ⚠️ **Before you run it:** Ralph runs the agent with `--permission-mode bypassPermissions` and, by default, bind-mounts the host Docker socket (**root-equivalent access to the host Docker daemon**). Only run it against repos, plans, and issues you trust; set `RALPH_DOCKER_SOCK=0` to disable the socket mount. Full threat model in [SECURITY.md](./SECURITY.md).
+
 ## 1. Prerequisites
 
 - **Docker** running — Docker Desktop (Windows/macOS) or Docker Engine (Linux).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Ralph — Autonomous Claude Code Loop
 
+[![@daonhan/ralph](https://img.shields.io/npm/v/@daonhan/ralph?label=%40daonhan%2Fralph)](https://www.npmjs.com/package/@daonhan/ralph)
+[![@daonhan/ralph-core](https://img.shields.io/npm/v/@daonhan/ralph-core?label=%40daonhan%2Fralph-core)](https://www.npmjs.com/package/@daonhan/ralph-core)
+[![CI](https://github.com/daonhan/ralph/actions/workflows/ci.yml/badge.svg)](https://github.com/daonhan/ralph/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
 Ralph drives [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) against a target repository in an iterating implementer → reviewer pipeline, isolated inside a custom Docker image. The harness ships as two npm packages, with thin bash shims that wire host paths + credentials into the CLI.
+
+> ⚠️ **Security:** Ralph runs Claude with `--permission-mode bypassPermissions` inside the sandbox and, **by default, bind-mounts the host Docker socket — granting root-equivalent access to the host Docker daemon.** Point it only at repositories, plans, and GitHub issues you trust. Disable the socket mount with `RALPH_DOCKER_SOCK=0`. See **[SECURITY.md](./SECURITY.md)** for the full threat model.
 
 > **New here?** Start with **[QUICKSTART.md](./QUICKSTART.md)** (zero-to-first-loop). Hacking on Ralph itself → **[CONTRIBUTING.md](./CONTRIBUTING.md)**. Internals → **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)**.
 
@@ -475,7 +482,7 @@ Set `RALPH_IMAGE=registry.example.com/my-image:tag` before invoking the shim, or
 
 ### Change feedback loops or task priority
 
-Edit `packages/core/templates/prompt.md` (and `ghprompt.md`) — the playbooks injected via `@include:prompt.md`.
+The shared task-priority ladder, feedback loops, commit rules, and final rules live in `packages/core/templates/playbook-common.md` (injected into both loops). The per-loop bespoke headers are `prompt.md` (plan/PRD source + progress recording, for `ralph-afk`) and `ghprompt.md` (issue triage + close/comment, for `ralph-ghafk`). `afk.md` / `ghafk.md` each `@include` their header plus `playbook-common.md`.
 
 ---
 
@@ -553,3 +560,9 @@ Edit `packages/core/templates/prompt.md` (and `ghprompt.md`) — the playbooks i
 | [`packages/core/templates/afk.md`](./packages/core/templates/afk.md)             | `ralph-afk` prompt template.                                                                                                                                                 |
 | [`packages/core/templates/ghafk.md`](./packages/core/templates/ghafk.md)         | `ralph-ghafk` prompt template.                                                                                                                                               |
 | [`packages/core/templates/review.md`](./packages/core/templates/review.md)       | Reviewer prompt template.                                                                                                                                                    |
+
+---
+
+## License
+
+[MIT](./LICENSE) (c) Paul Nguyen.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately via GitHub Security Advisories — open the repository's
+**[Security → Report a vulnerability](https://github.com/daonhan/ralph/security/advisories/new)**
+form — or email **daonhan@gmail.com**. Include a description, reproduction steps, and the
+affected version. You'll get an acknowledgement within a few days and a fix or mitigation plan.
+
+## Supported versions
+
+Only the latest published minor of each package (`@daonhan/ralph`, `@daonhan/ralph-core`) and
+the latest `ralph-sandbox` image are supported with security fixes. Pin by digest for the image
+and by exact version for the packages if you need reproducibility.
+
+## Threat model — read before running
+
+Ralph is an **autonomous agent harness**. By design it runs the Claude Code CLI with
+`--permission-mode bypassPermissions` inside the sandbox container, so the agent executes
+bash, edits, and tool calls **without interactive approval**. Treat everything it ingests as
+instructions it may act on. The trust boundary is:
+
+- **Only run Ralph against repositories, plans/PRDs, and GitHub issues you trust.** The plan/PRD
+  string (`{{ INPUTS }}`), issue bodies/comments (`ralph-ghafk`), and commit messages are all
+  fed to a `bypassPermissions` agent. `ralph-ghafk` in particular pulls **public GitHub issues**
+  — text authored by strangers — into that agent. Do not point it at a repo whose open issues
+  you have not vetted.
+
+- **The host Docker socket is bind-mounted by default**, which grants the sandbox
+  **root-equivalent access to the host Docker daemon** (it can start a sibling container that
+  bind-mounts the host filesystem as root). This is on so Testcontainers inside the sandbox can
+  spawn sibling containers. **Disable it with `RALPH_DOCKER_SOCK=0`** when running anything you
+  do not fully trust. With it disabled, the blast radius is bounded to the bind-mounted
+  workspace tree (git-recoverable).
+
+- **Host credentials are bind-mounted.** `~/.claude` and `~/.claude.json` are mounted
+  **read-write** (Claude refreshes its OAuth token by writing back), so the agent can read and
+  overwrite your Claude credentials. `~/.config/gh` is mounted read-only.
+
+### Reducing blast radius
+
+- Set `RALPH_DOCKER_SOCK=0` unless you specifically need Testcontainers.
+- Run Ralph on a disposable VM / dedicated machine, not your primary workstation, for untrusted
+  inputs.
+- Review open issues before running `ralph-ghafk`.
+- Use a scoped, short-lived `gh` token.
+
+## Template authoring (contributors)
+
+The prompt-template renderer (`render.ts`) executes the **command bodies** of the `` !`cmd` ``,
+`` !?`cmd` ``, and `@spill` tags on the **host shell**. The shipped templates only ever use
+**static** command strings, and `{{ INPUTS }}` is substituted last (written to a file the agent
+reads inside the container, never re-shelled on the host) — so there is no host command-injection
+vector today. **This invariant must be preserved:** never interpolate runtime or untrusted data
+into a tag command body. Doing so would create direct host RCE.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,41 @@
+# @daonhan/ralph
+
+CLI for **[Ralph](https://github.com/daonhan/ralph)** — a harness that drives the
+[Claude Code](https://docs.anthropic.com/claude/docs/claude-code) CLI against a target
+repository in an iterating implementer → reviewer loop, inside an ephemeral Docker sandbox.
+
+Exposes two bin entries (thin wrappers over
+**[`@daonhan/ralph-core`](https://www.npmjs.com/package/@daonhan/ralph-core)**):
+
+- **`ralph-afk`** — plan/PRD-driven loop. Iterates until the agent emits `<promise>NO MORE TASKS</promise>`.
+- **`ralph-ghafk`** — GitHub-issue-driven loop. Pulls open issues and lets the agent pick the next task.
+
+> **Security:** Ralph runs Claude with `--permission-mode bypassPermissions` inside the sandbox
+> and, by default, bind-mounts the host Docker socket (root-equivalent host access). Point it
+> only at repositories and prompts you trust. See
+> [SECURITY.md](https://github.com/daonhan/ralph/blob/main/SECURITY.md).
+
+## Install
+
+```bash
+npm i -g @daonhan/ralph
+```
+
+## Use
+
+```bash
+cd /path/to/your/workspace
+ralph-afk "<plan-and-prd>" 5      # plan/PRD loop
+ralph-ghafk 5                     # GitHub-issue loop
+ralph-afk --help                  # flags, env vars
+ralph-afk --print-config          # diagnose workspace / docker context / image / socket
+```
+
+Requires Docker and an authenticated Claude Code login (and `gh` for `ralph-ghafk`). First-run
+setup, per-OS notes, and the full flag/env reference are in the
+**[main README](https://github.com/daonhan/ralph#readme)** and
+**[QUICKSTART](https://github.com/daonhan/ralph/blob/main/QUICKSTART.md)**.
+
+## License
+
+[MIT](https://github.com/daonhan/ralph/blob/main/LICENSE) © Paul Nguyen.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -3,6 +3,26 @@
   "version": "0.6.1",
   "description": "CLI for the ralph AFK loop (ralph-afk, ralph-ghafk).",
   "type": "module",
+  "license": "MIT",
+  "author": "Paul Nguyen <daonhan@gmail.com>",
+  "homepage": "https://github.com/daonhan/ralph/tree/main/apps/cli#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/daonhan/ralph.git",
+    "directory": "apps/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/daonhan/ralph/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "ai-agent",
+    "afk",
+    "docker",
+    "automation",
+    "cli"
+  ],
   "bin": {
     "ralph-afk": "./bin/ralph-afk.js",
     "ralph-ghafk": "./bin/ralph-ghafk.js"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,9 +28,9 @@ The harness drives the Claude Code CLI against a target repository in an iterati
 ralph-afk / ralph-ghafk           bin (apps/cli/bin/*.js → import { runAfk|runGhAfk })
         │
         ▼
-runAfk / runGhAfk                 (main.ts / gh-main.ts)
+runAfk / runGhAfk                 (main.ts / gh-main.ts → runBin in run-bin.ts)
    parseFlags (cli-help.ts)       --help/-V/--print-config/--no-keep-alive/--max-retries/--detach/--log/--notify
-   resolve workspaceDir, ralphDir, sandcastleDir from env
+   resolve workspaceDir, ralphDir, packageDir from env
    [--detach] detachAndExit       fork-and-exit, parent returns 0
         │
         ▼
@@ -54,13 +54,13 @@ The bin layer is thin: it parses flags, resolves three directories, and calls `r
 
 `ensureImage` runs exactly once, before the iteration loop, so a missing/floating image is resolved a single time per run.
 
-Three resolved directories drive everything (set in `main.ts` / `gh-main.ts`):
+Three resolved directories drive everything (set in `run-bin.ts`, shared by both bins):
 
-| Dir             | Source                                    | Use                                                                   |
-| --------------- | ----------------------------------------- | --------------------------------------------------------------------- |
-| `workspaceDir`  | `RALPH_WORKSPACE` or `process.cwd()`      | Bind-mounted at `/home/agent/workspace`; host root for `.ralph-tmp/`. |
-| `ralphDir`      | `RALPH_DOCKER_CONTEXT` or `sandcastleDir` | `docker build` fallback context.                                      |
-| `sandcastleDir` | `resolve(dirname(import.meta.url), "..")` | The installed core package dir; `templates/` is read from here.       |
+| Dir            | Source                                    | Use                                                                   |
+| -------------- | ----------------------------------------- | --------------------------------------------------------------------- |
+| `workspaceDir` | `RALPH_WORKSPACE` or `process.cwd()`      | Bind-mounted at `/home/agent/workspace`; host root for `.ralph-tmp/`. |
+| `ralphDir`     | `RALPH_DOCKER_CONTEXT` or `packageDir`    | `docker build` fallback context.                                      |
+| `packageDir`   | `resolve(dirname(import.meta.url), "..")` | The installed core package dir; `templates/` is read from here.       |
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,8 @@
+# Implementation plans (internal, historical)
+
+These are internal, step-by-step implementation plans captured while building
+features. They may be **stale** — the **code is the source of truth**, and these
+documents are kept only for historical context, not as current documentation.
+
+For how Ralph works today, start with the root [README](../../README.md),
+[CONTRIBUTING](../../CONTRIBUTING.md), and [ARCHITECTURE](../ARCHITECTURE.md).

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -1,0 +1,8 @@
+# Product requirements (internal, historical)
+
+These are internal PRDs written during development. They describe intent at the
+time of writing and may be **stale or partially superseded** — the **code is the
+source of truth**. Kept for historical context, not as current documentation.
+
+For how Ralph works today, start with the root [README](../../README.md),
+[CONTRIBUTING](../../CONTRIBUTING.md), and [ARCHITECTURE](../ARCHITECTURE.md).

--- a/docs/prd/shrink-agent-playbooks.md
+++ b/docs/prd/shrink-agent-playbooks.md
@@ -1,5 +1,12 @@
 # PRD: Shrink Ralph Agent Playbooks
 
+> **Status (2026-06): partially superseded — not implemented as written.** The
+> cross-file duplication this PRD targets has since been removed by factoring the
+> shared playbook body into `packages/core/templates/playbook-common.md`
+> (`@include`d by both `afk.md` and `ghafk.md`), not via the `_task-ladder.md` /
+> `_feedback-loops.md` / `_commit-format.md` snippet files this document proposes —
+> those do not exist. Treat the snippet design below as historical.
+
 ## Context
 
 User wants iteration context windows smaller so the in-container Claude agent stays focused on the task. Investigation showed each stage already runs in a fresh `--rm` Docker container with a fresh `claude --print` session (runner.ts:206-247, loop.ts:36-72) — so the per-stage context budget is already isolated. The remaining lever is the **prompt itself**: the playbooks shipped at `packages/core/templates/*.md` carry redundant prose, cross-file duplication, and verbose explanations of concepts the agent already knows.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,18 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "license": "MIT",
+  "author": "Paul Nguyen <daonhan@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/daonhan/ralph.git"
+  },
   "packageManager": "pnpm@9.12.0",
   "scripts": {
     "build": "pnpm -r run build",
     "clean": "pnpm -r run clean",
     "typecheck": "pnpm -r run typecheck",
-    "test": "node --test",
+    "test": "node --test scripts/runner-floating-ref.test.mjs scripts/release-please-config.test.mjs scripts/update-status-table.test.mjs",
     "publish-all": "pnpm -r publish --access public --no-git-checks",
     "prepare": "husky"
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,51 @@
+# @daonhan/ralph-core
+
+Library half of **[Ralph](https://github.com/daonhan/ralph)** — a harness that drives the
+[Claude Code](https://docs.anthropic.com/claude/docs/claude-code) CLI against a target
+repository in an iterating implementer → reviewer loop, inside an ephemeral Docker sandbox.
+
+This package is the engine: the iteration loop driver, the Docker runner + NDJSON stream
+renderer, the prompt-template renderer, and the stage registry. The user-facing CLI lives in
+**[`@daonhan/ralph`](https://www.npmjs.com/package/@daonhan/ralph)** (`ralph-afk` / `ralph-ghafk`).
+
+> **Security:** Ralph runs Claude with `--permission-mode bypassPermissions` inside the sandbox
+> and, by default, bind-mounts the host Docker socket (root-equivalent host access). Point it
+> only at repositories and prompts you trust. See the repo's
+> [SECURITY.md](https://github.com/daonhan/ralph/blob/main/SECURITY.md).
+
+## Install
+
+```bash
+npm i @daonhan/ralph-core
+```
+
+## Use
+
+```ts
+import {
+  runAfk,
+  runGhAfk,
+  runLoop,
+  STAGES,
+  renderTemplate,
+} from "@daonhan/ralph-core";
+
+// Drive the plan/PRD loop from argv (same entry the ralph-afk bin uses):
+await runAfk(["<plan-and-prd>", "5"]);
+```
+
+Public surface: `runAfk`, `runGhAfk`, `runLoop`, `STAGES`, `Stage`, `renderTemplate`,
+`ensureImage`, `runStage`. Subpath exports: `./loop`, `./runner`, `./stages`.
+
+The `templates/` directory (prompt playbooks + the `ralph-sandbox` `Dockerfile`) ships in the
+tarball and is the default `docker build` fallback context.
+
+## Docs
+
+Full usage, setup, environment variables, and architecture are in the
+**[main README](https://github.com/daonhan/ralph#readme)** and
+**[docs/ARCHITECTURE.md](https://github.com/daonhan/ralph/blob/main/docs/ARCHITECTURE.md)**.
+
+## License
+
+[MIT](https://github.com/daonhan/ralph/blob/main/LICENSE) © Paul Nguyen.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,27 @@
   "version": "0.6.1",
   "description": "Claude Code AFK orchestration: iteration loop, docker runner, template renderer.",
   "type": "module",
+  "license": "MIT",
+  "author": "Paul Nguyen <daonhan@gmail.com>",
+  "homepage": "https://github.com/daonhan/ralph/tree/main/packages/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/daonhan/ralph.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/daonhan/ralph/issues"
+  },
+  "keywords": [
+    "claude-code",
+    "claude",
+    "ai-agent",
+    "afk",
+    "docker",
+    "automation",
+    "code-review",
+    "orchestration"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/core/src/__tests__/loop.test.ts
+++ b/packages/core/src/__tests__/loop.test.ts
@@ -39,6 +39,9 @@ vi.mock("../runner.js", () => ({
       "logs",
       `iter${iteration}-${stageName}.ndjson`
     ),
+}));
+
+vi.mock("../stream-render.js", () => ({
   USE_COLOR: false,
   dim: (s: string) => s,
   bold: (s: string) => s,
@@ -58,26 +61,26 @@ const sentinel = "<promise>NO MORE TASKS</promise>";
 type LoopDirs = {
   root: string;
   ralphDir: string;
-  sandcastleDir: string;
+  packageDir: string;
   workspaceDir: string;
 };
 
 function makeDirs(): LoopDirs {
   const root = mkdtempSync(join(tmpdir(), "ralph-loop-"));
   const ralphDir = join(root, "ralph");
-  const sandcastleDir = join(root, "sandcastle");
+  const packageDir = join(root, "sandcastle");
   const workspaceDir = join(root, "workspace");
 
-  mkdirSync(join(sandcastleDir, "templates"), { recursive: true });
+  mkdirSync(join(packageDir, "templates"), { recursive: true });
   mkdirSync(ralphDir, { recursive: true });
   mkdirSync(workspaceDir, { recursive: true });
   writeFileSync(
-    join(sandcastleDir, "templates", stage.template),
+    join(packageDir, "templates", stage.template),
     "run {{ INPUTS }}",
     "utf8"
   );
 
-  return { root, ralphDir, sandcastleDir, workspaceDir };
+  return { root, ralphDir, packageDir, workspaceDir };
 }
 
 function loopOptions(dirs: LoopDirs, overrides = {}) {
@@ -87,7 +90,7 @@ function loopOptions(dirs: LoopDirs, overrides = {}) {
     iterations: 1,
     ralphDir: dirs.ralphDir,
     workspaceDir: dirs.workspaceDir,
-    sandcastleDir: dirs.sandcastleDir,
+    packageDir: dirs.packageDir,
     ...overrides,
   };
 }

--- a/packages/core/src/cli-help.ts
+++ b/packages/core/src/cli-help.ts
@@ -166,7 +166,7 @@ export function printConfig(
   bin: string,
   workspaceDir: string,
   ralphDir: string,
-  sandcastleDir: string,
+  packageDir: string,
   opts: PrintConfigOptions = {}
 ): void {
   const {
@@ -215,7 +215,7 @@ export function printConfig(
   RALPH_DOCKER_CONTEXT  ${ralphDir}${process.env.RALPH_DOCKER_CONTEXT ? "" : "  (default: bundled core dir)"}
   RALPH_IMAGE           ${IMAGE_REF}${process.env.RALPH_IMAGE || process.env.RALPH_IMAGE_TAG ? "" : "  (default)"}
   Dockerfile at ctx     ${dfPresent ? "present" : "MISSING"} (${dockerfile})
-  sandcastleDir         ${sandcastleDir}
+  packageDir            ${packageDir}
   RALPH_DOCKER_SOCK     ${sockStatus}
   keep-alive            ${keepAliveStatus}
   max-retries           ${maxRetries}

--- a/packages/core/src/gh-main.ts
+++ b/packages/core/src/gh-main.ts
@@ -1,19 +1,5 @@
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import {
-  parseFlags,
-  printConfig,
-  printHelp,
-  printVersion,
-} from "./cli-help.js";
-import { detachAndExit } from "./detach.js";
-import { runLoop } from "./loop.js";
+import { runBin } from "./run-bin.js";
 import { STAGES } from "./stages.js";
-
-const BIN = "ralph-ghafk";
-const USAGE = "<iterations>";
-const DESC = "GitHub-issue-driven Claude Code AFK loop";
 
 export type RunGhAfkOptions = { cliVersion?: string };
 
@@ -21,68 +7,12 @@ export async function runGhAfk(
   argv: string[],
   opts: RunGhAfkOptions = {}
 ): Promise<void> {
-  const flags = parseFlags(argv);
-
-  if (flags.version) {
-    printVersion(BIN, opts.cliVersion);
-    return;
-  }
-  if (flags.help) {
-    printHelp(BIN, USAGE, DESC);
-    return;
-  }
-
-  const here = dirname(fileURLToPath(import.meta.url));
-  const sandcastleDir = resolve(here, "..");
-  const workspaceDir = resolve(process.env.RALPH_WORKSPACE ?? process.cwd());
-  const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
-
-  const detachLogPath = flags.detach
-    ? (flags.log ??
-      join(workspaceDir, ".ralph-tmp", "logs", `detached-${process.pid}.log`))
-    : undefined;
-
-  if (flags.printConfig) {
-    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
-      cliVersion: opts.cliVersion,
-      noKeepAlive: flags.noKeepAlive,
-      maxRetries: flags.maxRetries,
-      detach: flags.detach,
-      detachLogPath,
-      notify: flags.notify,
-    });
-    return;
-  }
-
-  const [iterationsArg] = flags.rest;
-  if (!iterationsArg) {
-    console.error(`Usage: ${BIN} ${USAGE}`);
-    console.error(`       ${BIN} --help`);
-    process.exit(1);
-  }
-  const iterations = Number.parseInt(iterationsArg, 10);
-  if (!Number.isFinite(iterations) || iterations < 1) {
-    console.error(`Invalid iterations: ${iterationsArg}`);
-    process.exit(1);
-  }
-
-  if (flags.detach && detachLogPath) {
-    detachAndExit({
-      logPath: detachLogPath,
-      argv,
-      binEntry: process.argv[1],
-    });
-  }
-
-  await runLoop({
+  await runBin(argv, {
+    bin: "ralph-ghafk",
+    usage: "<iterations>",
+    desc: "GitHub-issue-driven Claude Code AFK loop",
     stages: [STAGES.ghafkImplementer, STAGES.reviewer],
-    inputs: "",
-    iterations,
-    ralphDir,
-    workspaceDir,
-    sandcastleDir,
-    noKeepAlive: flags.noKeepAlive,
-    maxRetries: flags.maxRetries,
-    notify: flags.notify,
+    takesInputArg: false,
+    cliVersion: opts.cliVersion,
   });
 }

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -10,10 +10,8 @@ import {
   backoffFor,
   withRetries,
 } from "./retry.js";
+import { ensureImage, runStage, stageLogPath } from "./runner.js";
 import {
-  ensureImage,
-  runStage,
-  stageLogPath,
   USE_COLOR,
   dim,
   bold,
@@ -23,9 +21,11 @@ import {
   dimOut,
   SYM,
   SYM_OUT,
-} from "./runner.js";
+} from "./stream-render.js";
 import type { Stage } from "./stages.js";
 
+// The agent emits this literal when there is no more work; the same string is
+// mirrored in the playbook templates (prompt.md / ghprompt.md) that instruct it.
 const SENTINEL = "<promise>NO MORE TASKS</promise>";
 
 export type LoopOptions = {
@@ -34,9 +34,12 @@ export type LoopOptions = {
   stages: [Stage, ...Stage[]];
   inputs: string;
   iterations: number;
+  /** Docker `build` fallback context (must contain a Dockerfile). */
   ralphDir: string;
+  /** Host repo bind-mounted into the sandbox at /home/agent/workspace. */
   workspaceDir: string;
-  sandcastleDir: string;
+  /** Installed @daonhan/ralph-core dir; stage templates are read from <packageDir>/templates. */
+  packageDir: string;
   /** When true, skip OS wake-lock acquisition. Default: false. */
   noKeepAlive?: boolean;
   /** Per-stage retry budget. Default: 3. Set to 0 to disable retries. */
@@ -52,7 +55,7 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     iterations,
     ralphDir,
     workspaceDir,
-    sandcastleDir,
+    packageDir,
     noKeepAlive = false,
     maxRetries = DEFAULT_MAX_RETRIES,
     notify = false,
@@ -102,7 +105,7 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
           ? `${dim("\u2501\u2501\u2501")} ${bold(`iteration ${i}/${iterations}`)} ${dim("\u00b7")} ${bold(stage.name)} ${dim(`(stage ${s + 1}/${stages.length})`)} ${dim("\u2501\u2501\u2501")}`
           : `== iteration ${i}/${iterations} \u00b7 ${stage.name} (stage ${s + 1}/${stages.length}) ==`;
         process.stderr.write(`\n${banner}\n`);
-        const templatePath = join(sandcastleDir, "templates", stage.template);
+        const templatePath = join(packageDir, "templates", stage.template);
         const spillRel = `spill-${process.pid}-${i}-${s}-${Date.now()}`;
         const spillHostDir = join(workspaceDir, ".ralph-tmp", spillRel);
         const spillRefPath = posix.join(".ralph-tmp", spillRel);

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,19 +1,5 @@
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-
-import {
-  parseFlags,
-  printConfig,
-  printHelp,
-  printVersion,
-} from "./cli-help.js";
-import { detachAndExit } from "./detach.js";
-import { runLoop } from "./loop.js";
+import { runBin } from "./run-bin.js";
 import { STAGES } from "./stages.js";
-
-const BIN = "ralph-afk";
-const USAGE = "<plan-and-prd> <iterations>";
-const DESC = "plan/PRD-driven Claude Code AFK loop";
 
 export type RunAfkOptions = { cliVersion?: string };
 
@@ -21,68 +7,12 @@ export async function runAfk(
   argv: string[],
   opts: RunAfkOptions = {}
 ): Promise<void> {
-  const flags = parseFlags(argv);
-
-  if (flags.version) {
-    printVersion(BIN, opts.cliVersion);
-    return;
-  }
-  if (flags.help) {
-    printHelp(BIN, USAGE, DESC);
-    return;
-  }
-
-  const here = dirname(fileURLToPath(import.meta.url));
-  const sandcastleDir = resolve(here, "..");
-  const workspaceDir = resolve(process.env.RALPH_WORKSPACE ?? process.cwd());
-  const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? sandcastleDir);
-
-  const detachLogPath = flags.detach
-    ? (flags.log ??
-      join(workspaceDir, ".ralph-tmp", "logs", `detached-${process.pid}.log`))
-    : undefined;
-
-  if (flags.printConfig) {
-    printConfig(BIN, workspaceDir, ralphDir, sandcastleDir, {
-      cliVersion: opts.cliVersion,
-      noKeepAlive: flags.noKeepAlive,
-      maxRetries: flags.maxRetries,
-      detach: flags.detach,
-      detachLogPath,
-      notify: flags.notify,
-    });
-    return;
-  }
-
-  const [planAndPrd, iterationsArg] = flags.rest;
-  if (!planAndPrd || !iterationsArg) {
-    console.error(`Usage: ${BIN} ${USAGE}`);
-    console.error(`       ${BIN} --help`);
-    process.exit(1);
-  }
-  const iterations = Number.parseInt(iterationsArg, 10);
-  if (!Number.isFinite(iterations) || iterations < 1) {
-    console.error(`Invalid iterations: ${iterationsArg}`);
-    process.exit(1);
-  }
-
-  if (flags.detach && detachLogPath) {
-    detachAndExit({
-      logPath: detachLogPath,
-      argv,
-      binEntry: process.argv[1],
-    });
-  }
-
-  await runLoop({
+  await runBin(argv, {
+    bin: "ralph-afk",
+    usage: "<plan-and-prd> <iterations>",
+    desc: "plan/PRD-driven Claude Code AFK loop",
     stages: [STAGES.implementer, STAGES.reviewer],
-    inputs: planAndPrd,
-    iterations,
-    ralphDir,
-    workspaceDir,
-    sandcastleDir,
-    noKeepAlive: flags.noKeepAlive,
-    maxRetries: flags.maxRetries,
-    notify: flags.notify,
+    takesInputArg: true,
+    cliVersion: opts.cliVersion,
   });
 }

--- a/packages/core/src/render.ts
+++ b/packages/core/src/render.ts
@@ -2,6 +2,13 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 
+// SECURITY INVARIANT: the command bodies of the !`cmd`, !?`cmd`, and @spill tags
+// are executed on the HOST shell (see execSync calls below). Templates are trusted
+// (shipped in the npm tarball) and only ever embed STATIC command strings; {{ INPUTS }}
+// is substituted LAST, into the already-expanded text, and is never re-shelled. Never
+// author a tag whose command body interpolates runtime or untrusted data (issue bodies,
+// commit messages, INPUTS, branch names) — that would be direct host RCE. See SECURITY.md.
+
 // Order matters: !?`...` (try-shell w/ ||| fallback) must match before plain !`...`.
 const SHELL_TRY_TAG = /!\?`([^`]+)`/g;
 const SHELL_TAG = /!`([^`]+)`/g;
@@ -12,6 +19,9 @@ const INCLUDE_TAG = /@include:([^\s`)]+)/g;
 const SPILL_TAG = /@spill(\??):([^\s=]+)=`([^`]+)`/g;
 const INPUTS_TAG = /\{\{\s*INPUTS\s*\}\}/g;
 const TRY_SEP = "|||";
+// Cap on captured stdout for every shell/@spill tag (64 MiB). Large outputs are
+// meant to go through @spill (written to a file), not be inlined into the prompt.
+const SPILL_MAX_BUFFER = 64 * 1024 * 1024;
 
 export type RenderVars = {
   INPUTS: string;
@@ -89,7 +99,7 @@ export function renderTemplate(
         out = execSync(cmd, {
           shell,
           encoding: "utf8",
-          maxBuffer: 64 * 1024 * 1024,
+          maxBuffer: SPILL_MAX_BUFFER,
           cwd: opts.cwd,
           stdio: ["ignore", "pipe", tryMode ? "ignore" : "pipe"],
         });
@@ -113,7 +123,7 @@ export function renderTemplate(
         const out = execSync(cmd, {
           shell,
           encoding: "utf8",
-          maxBuffer: 64 * 1024 * 1024,
+          maxBuffer: SPILL_MAX_BUFFER,
           cwd: opts.cwd,
           stdio: ["ignore", "pipe", "ignore"],
         });

--- a/packages/core/src/run-bin.ts
+++ b/packages/core/src/run-bin.ts
@@ -1,0 +1,105 @@
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  parseFlags,
+  printConfig,
+  printHelp,
+  printVersion,
+} from "./cli-help.js";
+import { detachAndExit } from "./detach.js";
+import { runLoop } from "./loop.js";
+import type { Stage } from "./stages.js";
+
+export type RunBinConfig = {
+  /** Bin name for usage/version/config output (e.g. "ralph-afk"). */
+  bin: string;
+  /** Positional-arg usage string (e.g. "<plan-and-prd> <iterations>"). */
+  usage: string;
+  /** One-line description for --help. */
+  desc: string;
+  /** Stage chain; first stage is the gate. */
+  stages: [Stage, ...Stage[]];
+  /**
+   * Whether the bin takes a leading input positional before <iterations>.
+   * `true`  → argv is `<inputs> <iterations>` (ralph-afk; inputs = rest[0]).
+   * `false` → argv is `<iterations>`          (ralph-ghafk; inputs = "").
+   */
+  takesInputArg: boolean;
+  cliVersion?: string;
+};
+
+/**
+ * Shared entry for the AFK bins: parse flags, handle --version/--help/--print-config,
+ * resolve the workspace / docker-context / package dirs, validate the positional args,
+ * optionally fork into the background (--detach), then drive runLoop.
+ */
+export async function runBin(argv: string[], cfg: RunBinConfig): Promise<void> {
+  const flags = parseFlags(argv);
+
+  if (flags.version) {
+    printVersion(cfg.bin, cfg.cliVersion);
+    return;
+  }
+  if (flags.help) {
+    printHelp(cfg.bin, cfg.usage, cfg.desc);
+    return;
+  }
+
+  // run-bin.js ships in the same dist/ dir as the bin entrypoints, so ".." is
+  // the installed @daonhan/ralph-core package dir (which holds templates/).
+  const here = dirname(fileURLToPath(import.meta.url));
+  const packageDir = resolve(here, "..");
+  const workspaceDir = resolve(process.env.RALPH_WORKSPACE ?? process.cwd());
+  const ralphDir = resolve(process.env.RALPH_DOCKER_CONTEXT ?? packageDir);
+
+  const detachLogPath = flags.detach
+    ? (flags.log ??
+      join(workspaceDir, ".ralph-tmp", "logs", `detached-${process.pid}.log`))
+    : undefined;
+
+  if (flags.printConfig) {
+    printConfig(cfg.bin, workspaceDir, ralphDir, packageDir, {
+      cliVersion: cfg.cliVersion,
+      noKeepAlive: flags.noKeepAlive,
+      maxRetries: flags.maxRetries,
+      detach: flags.detach,
+      detachLogPath,
+      notify: flags.notify,
+    });
+    return;
+  }
+
+  const inputs = cfg.takesInputArg ? flags.rest[0] : "";
+  const iterationsArg = cfg.takesInputArg ? flags.rest[1] : flags.rest[0];
+  if ((cfg.takesInputArg && !inputs) || !iterationsArg) {
+    console.error(`Usage: ${cfg.bin} ${cfg.usage}`);
+    console.error(`       ${cfg.bin} --help`);
+    process.exit(1);
+  }
+  const iterations = Number.parseInt(iterationsArg, 10);
+  if (!Number.isFinite(iterations) || iterations < 1) {
+    console.error(`Invalid iterations: ${iterationsArg}`);
+    process.exit(1);
+  }
+
+  if (flags.detach && detachLogPath) {
+    detachAndExit({
+      logPath: detachLogPath,
+      argv,
+      binEntry: process.argv[1],
+    });
+  }
+
+  await runLoop({
+    stages: cfg.stages,
+    inputs: inputs ?? "",
+    iterations,
+    ralphDir,
+    workspaceDir,
+    packageDir,
+    noKeepAlive: flags.noKeepAlive,
+    maxRetries: flags.maxRetries,
+    notify: flags.notify,
+  });
+}

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -13,6 +13,15 @@ import { createInterface } from "node:readline";
 import { join, posix } from "node:path";
 
 import type { Stage } from "./stages.js";
+import {
+  bold,
+  dim,
+  red,
+  renderEvent,
+  SYM,
+  type StreamJson,
+  type ToolTrack,
+} from "./stream-render.js";
 
 export type RunStageOptions = {
   signal?: AbortSignal;
@@ -24,6 +33,9 @@ export const IMAGE_REF =
   "docker.io/daonhan/ralph-sandbox:latest";
 const STDERR_TAIL_LINES = 40;
 const DEFAULT_RESULT_GRACE_MS = 30_000;
+
+// Emit the docker.sock blast-radius warning at most once per process.
+let dockerSockWarned = false;
 
 /**
  * Parse `RALPH_RESULT_GRACE_MS`. Returns the configured millisecond budget,
@@ -42,84 +54,6 @@ export function parseGraceMs(
   if (n < 0) return defaultMs;
   return Math.floor(n);
 }
-const TOOL_INPUT_PREVIEW = 200;
-const TOOL_RESULT_PREVIEW = 120;
-const TOOL_ERROR_PREVIEW = 400;
-
-/* ── TTY-gated styling ────────────────────────────────────────────────── */
-
-const NO_COLOR_ENV =
-  process.env.NO_COLOR != null || process.env.TERM === "dumb";
-
-/** Controls ANSI codes on stderr (tool events, banners, docker output). */
-const USE_COLOR = process.stderr.isTTY === true && !NO_COLOR_ENV;
-
-/** Controls ANSI codes on stdout (assistant text bullets, completion line).
- *  Separate from USE_COLOR so `ralph-ghafk 1 > out.txt` stays clean even
- *  when stderr is still a TTY. */
-const USE_COLOR_STDOUT = process.stdout.isTTY === true && !NO_COLOR_ENV;
-
-const c = (code: string, s: string): string =>
-  USE_COLOR ? `\x1b[${code}m${s}\x1b[0m` : s;
-const cOut = (code: string, s: string): string =>
-  USE_COLOR_STDOUT ? `\x1b[${code}m${s}\x1b[0m` : s;
-const dim = (s: string): string => c("2", s);
-const bold = (s: string): string => c("1", s);
-const cyan = (s: string): string => c("36", s);
-const green = (s: string): string => c("32", s);
-const red = (s: string): string => c("31", s);
-const boldOut = (s: string): string => cOut("1", s);
-const cyanOut = (s: string): string => cOut("36", s);
-const greenOut = (s: string): string => cOut("32", s);
-const dimOut = (s: string): string => cOut("2", s);
-
-const SYM = USE_COLOR
-  ? { bullet: "●", cont: "⎿", check: "✓", cross: "✗", rule: "━", ellip: "…" }
-  : {
-      bullet: "*",
-      cont: "  >",
-      check: "ok",
-      cross: "FAIL",
-      rule: "=",
-      ellip: "...",
-    };
-
-const SYM_OUT = USE_COLOR_STDOUT ? { bullet: "●" } : { bullet: "*" };
-
-export {
-  USE_COLOR,
-  USE_COLOR_STDOUT,
-  dim,
-  bold,
-  cyan,
-  green,
-  red,
-  SYM,
-  greenOut,
-  boldOut,
-  dimOut,
-  SYM_OUT,
-};
-
-type AssistantBlock = {
-  type: string;
-  text?: string;
-  name?: string;
-  input?: unknown;
-  id?: string;
-};
-type UserBlock = {
-  type: string;
-  content?: unknown;
-  is_error?: boolean;
-  tool_use_id?: string;
-};
-type StreamJson =
-  | { type: "assistant"; message?: { content?: AssistantBlock[] } }
-  | { type: "user"; message?: { content?: UserBlock[] } }
-  | { type: "system"; subtype?: string; [k: string]: unknown }
-  | { type: "result"; result?: string; is_error?: boolean }
-  | { type: string; [k: string]: unknown };
 
 /**
  * Locate the sandbox Dockerfile within a build context. The Dockerfile lives at
@@ -308,25 +242,22 @@ function runDockerCommand(
   });
 }
 
-function ensureImageSync(buildContext?: string): void {
-  const floating = isFloatingRef(IMAGE_REF);
-  const hasLocal =
-    spawnSync("docker", ["image", "inspect", IMAGE_REF], { stdio: "ignore" })
-      .status === 0;
-
-  if (hasLocal && !floating) return;
-
-  process.stderr.write(`${dim("pulling")} ${IMAGE_REF}\n`);
-  const pull = spawnSync("docker", ["pull", IMAGE_REF], { stdio: "inherit" });
-  if (pull.status === 0) return;
-
+/**
+ * Shared post-pull-failure decision for both ensureImage variants. Returns the
+ * Dockerfile path to build from, or `null` to mean "fall back to the cached
+ * local copy". Throws when neither pull nor build is possible. Emits the same
+ * stderr messages both code paths used to duplicate.
+ */
+function resolveBuildAfterPullFail(
+  hasLocal: boolean,
+  buildContext: string | undefined
+): string | null {
   if (hasLocal) {
     process.stderr.write(
       `${dim("pull failed; using cached local copy of")} ${IMAGE_REF}\n`
     );
-    return;
+    return null;
   }
-
   if (!buildContext) {
     throw new Error(
       `docker pull failed for ${IMAGE_REF} and no build context provided. ` +
@@ -343,12 +274,29 @@ function ensureImageSync(buildContext?: string): void {
   process.stderr.write(
     `${dim("pull failed; building")} ${IMAGE_REF} ${dim("from")} ${buildContext}\n`
   );
+  return dockerfile;
+}
+
+function ensureImageSync(buildContext?: string): void {
+  const hasLocal =
+    spawnSync("docker", ["image", "inspect", IMAGE_REF], { stdio: "ignore" })
+      .status === 0;
+
+  if (hasLocal && !isFloatingRef(IMAGE_REF)) return;
+
+  process.stderr.write(`${dim("pulling")} ${IMAGE_REF}\n`);
+  if (
+    spawnSync("docker", ["pull", IMAGE_REF], { stdio: "inherit" }).status === 0
+  )
+    return;
+
+  const dockerfile = resolveBuildAfterPullFail(hasLocal, buildContext);
+  if (dockerfile === null) return;
+
   const build = spawnSync(
     "docker",
-    ["build", "-t", IMAGE_REF, "-f", dockerfile, buildContext],
-    {
-      stdio: "inherit",
-    }
+    ["build", "-t", IMAGE_REF, "-f", dockerfile, buildContext as string],
+    { stdio: "inherit" }
   );
   if (build.status !== 0) {
     throw new Error(`docker build failed (exit ${build.status})`);
@@ -359,14 +307,13 @@ async function ensureImageAsync(
   buildContext: string | undefined,
   options: RunStageOptions
 ): Promise<void> {
-  const floating = isFloatingRef(IMAGE_REF);
   const hasLocal =
     (await runDockerCommand(["image", "inspect", IMAGE_REF], {
       stdio: "ignore",
       signal: options.signal,
     })) === 0;
 
-  if (hasLocal && !floating) return;
+  if (hasLocal && !isFloatingRef(IMAGE_REF)) return;
 
   process.stderr.write(`${dim("pulling")} ${IMAGE_REF}\n`);
   const pullStatus = await runDockerCommand(["pull", IMAGE_REF], {
@@ -375,31 +322,11 @@ async function ensureImageAsync(
   });
   if (pullStatus === 0) return;
 
-  if (hasLocal) {
-    process.stderr.write(
-      `${dim("pull failed; using cached local copy of")} ${IMAGE_REF}\n`
-    );
-    return;
-  }
+  const dockerfile = resolveBuildAfterPullFail(hasLocal, buildContext);
+  if (dockerfile === null) return;
 
-  if (!buildContext) {
-    throw new Error(
-      `docker pull failed for ${IMAGE_REF} and no build context provided. ` +
-        `Set RALPH_DOCKER_CONTEXT to a directory containing a Dockerfile, ` +
-        `or override RALPH_IMAGE to an image you can pull.`
-    );
-  }
-  const dockerfile = resolveDockerfile(buildContext);
-  if (!existsSync(dockerfile)) {
-    throw new Error(
-      `docker pull failed for ${IMAGE_REF} and no Dockerfile at ${dockerfile}`
-    );
-  }
-  process.stderr.write(
-    `${dim("pull failed; building")} ${IMAGE_REF} ${dim("from")} ${buildContext}\n`
-  );
   const buildStatus = await runDockerCommand(
-    ["build", "-t", IMAGE_REF, "-f", dockerfile, buildContext],
+    ["build", "-t", IMAGE_REF, "-f", dockerfile, buildContext as string],
     {
       stdio: "inherit",
       signal: options.signal,
@@ -496,7 +423,16 @@ export async function runStage(
     }
 
     const sockMount = resolveDockerSocketMount();
-    if (sockMount) args.push(...sockMount);
+    if (sockMount) {
+      if (!dockerSockWarned) {
+        dockerSockWarned = true;
+        const sockPath = detectDockerSocketPath() ?? "docker.sock";
+        process.stderr.write(
+          `${red(SYM.bullet)} ${bold("docker.sock mounted")} ${dim(`(${sockPath}) — the sandbox has root-equivalent access to the host Docker daemon. Disable with RALPH_DOCKER_SOCK=0. See SECURITY.md.`)}\n`
+        );
+      }
+      args.push(...sockMount);
+    }
 
     args.push(
       IMAGE_REF,
@@ -653,137 +589,4 @@ function streamDocker(
       resolveOnce(finalResult);
     });
   });
-}
-
-type ToolTrack = { name: string; startedAt: number };
-
-function renderEvent(ev: StreamJson, toolMap: Map<string, ToolTrack>): void {
-  switch (ev.type) {
-    case "system": {
-      const sub = (ev as { subtype?: string }).subtype;
-      if (sub === "init") {
-        const model = (ev as { model?: string }).model ?? "?";
-        const cwd = (ev as { cwd?: string }).cwd ?? "?";
-        process.stderr.write(
-          `${dim("───")} ${bold("init")} ${dim(`model=${model} cwd=${cwd}`)}\n`
-        );
-      }
-      return;
-    }
-    case "assistant": {
-      const content =
-        (ev as { message?: { content?: AssistantBlock[] } }).message?.content ??
-        [];
-      for (const block of content) {
-        if (block.type === "text" && typeof block.text === "string") {
-          const lines = block.text.split("\n");
-          const formatted = lines
-            .map((l, idx) =>
-              idx === 0 ? `${boldOut(cyanOut(SYM_OUT.bullet))} ${l}` : `  ${l}`
-            )
-            .join("\r\n");
-          process.stdout.write(formatted + "\r\n\n");
-        } else if (block.type === "thinking") {
-          process.stderr.write(
-            `${dim(SYM.bullet + " thinking" + SYM.ellip)}\n`
-          );
-        } else if (block.type === "tool_use") {
-          const name = block.name ?? "?";
-          const preview = previewInput(name, block.input);
-          if (block.id) {
-            toolMap.set(block.id, { name, startedAt: Date.now() });
-          }
-          process.stderr.write(
-            `${cyan(SYM.bullet)} ${bold(name)} ${dim(preview)}\n`
-          );
-        }
-      }
-      return;
-    }
-    case "user": {
-      const content =
-        (ev as { message?: { content?: UserBlock[] } }).message?.content ?? [];
-      for (const block of content) {
-        if (block.type !== "tool_result") continue;
-        const text = stringifyToolResult(block.content);
-        const tracked = block.tool_use_id
-          ? toolMap.get(block.tool_use_id)
-          : undefined;
-        const toolName = tracked?.name ?? "tool";
-        const elapsed = tracked ? ` (${Date.now() - tracked.startedAt}ms)` : "";
-        if (block.tool_use_id) toolMap.delete(block.tool_use_id);
-
-        if (block.is_error) {
-          const snippet = text
-            .replace(/\s+/g, " ")
-            .trim()
-            .slice(0, TOOL_ERROR_PREVIEW);
-          process.stderr.write(
-            `${dim(SYM.cont)} ${red(SYM.cross)} ${bold(toolName)}${red(" failed")}\n  ${red(snippet)}${text.length > snippet.length ? " " + SYM.ellip : ""}\n`
-          );
-        } else {
-          const snippet = text
-            .replace(/\s+/g, " ")
-            .trim()
-            .slice(0, TOOL_RESULT_PREVIEW);
-          process.stderr.write(
-            `${dim(SYM.cont)} ${green(SYM.check)} ${bold(toolName)}${dim(elapsed)} ${dim(snippet)}${text.length > snippet.length ? " " + SYM.ellip : ""}\n`
-          );
-        }
-      }
-      return;
-    }
-    case "result": {
-      const isError = (ev as { is_error?: boolean }).is_error;
-      if (isError)
-        process.stderr.write(`${red(SYM.bullet + " result errored")}\n`);
-      return;
-    }
-    default:
-      return;
-  }
-}
-
-function previewInput(toolName: string, input: unknown): string {
-  if (input == null || typeof input !== "object") return "";
-  const obj = input as Record<string, unknown>;
-  // Pick the most informative field per tool.
-  const keyOrder: Record<string, string[]> = {
-    Bash: ["command"],
-    Edit: ["file_path"],
-    Write: ["file_path"],
-    Read: ["file_path"],
-    Glob: ["pattern", "path"],
-    Grep: ["pattern", "path"],
-    TodoWrite: [],
-  };
-  const keys = keyOrder[toolName] ?? Object.keys(obj).slice(0, 2);
-  const parts: string[] = [];
-  for (const k of keys) {
-    const v = obj[k];
-    if (v == null) continue;
-    const s = typeof v === "string" ? v : JSON.stringify(v);
-    parts.push(`${k}=${truncate(s, TOOL_INPUT_PREVIEW)}`);
-  }
-  return parts.join(" ");
-}
-
-function stringifyToolResult(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((c) => {
-        if (typeof c === "string") return c;
-        if (c && typeof c === "object" && "text" in c)
-          return String((c as { text: unknown }).text ?? "");
-        return JSON.stringify(c);
-      })
-      .join("\n");
-  }
-  return JSON.stringify(content ?? "");
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max - 1) + SYM.ellip;
 }

--- a/packages/core/src/stages.ts
+++ b/packages/core/src/stages.ts
@@ -4,10 +4,15 @@ export type Stage = {
   permissionMode?: string;
 };
 
-// All stages run inside the ephemeral ralph-sandbox container (--rm,
-// bind-mounted workspace only). Bash + edits must auto-approve for AFK to
-// work non-interactively, so every stage uses bypassPermissions. Worst-case
-// blast radius is the workspace tree, recoverable via git.
+// All stages run inside the ephemeral ralph-sandbox container (--rm). Bash +
+// edits must auto-approve for AFK to work non-interactively, so every stage
+// uses bypassPermissions.
+//
+// Blast radius depends on the docker.sock mount (on by default — see
+// resolveDockerSocketMount in runner.ts): with the socket mounted the agent
+// has root-equivalent access to the host Docker daemon (effectively the whole
+// host); with RALPH_DOCKER_SOCK=0 it is bounded to the bind-mounted workspace
+// tree, which is git-recoverable. See SECURITY.md.
 export const STAGES = {
   implementer: {
     name: "implementer",

--- a/packages/core/src/stream-render.ts
+++ b/packages/core/src/stream-render.ts
@@ -1,0 +1,206 @@
+/**
+ * Terminal pretty-printer for the Claude CLI's NDJSON stream, plus the TTY-gated
+ * ANSI styling primitives. Extracted from runner.ts: this module has no docker
+ * dependency — `renderEvent` consumes an already-parsed stream event and writes
+ * assistant text to stdout and tool/diagnostic events to stderr.
+ */
+
+const TOOL_INPUT_PREVIEW = 200;
+const TOOL_RESULT_PREVIEW = 120;
+const TOOL_ERROR_PREVIEW = 400;
+
+/* ── TTY-gated styling ────────────────────────────────────────────────── */
+
+const NO_COLOR_ENV =
+  process.env.NO_COLOR != null || process.env.TERM === "dumb";
+
+/** Controls ANSI codes on stderr (tool events, banners, docker output). */
+export const USE_COLOR = process.stderr.isTTY === true && !NO_COLOR_ENV;
+
+/** Controls ANSI codes on stdout (assistant text bullets, completion line).
+ *  Separate from USE_COLOR so `ralph-ghafk 1 > out.txt` stays clean even
+ *  when stderr is still a TTY. */
+const USE_COLOR_STDOUT = process.stdout.isTTY === true && !NO_COLOR_ENV;
+
+const c = (code: string, s: string): string =>
+  USE_COLOR ? `\x1b[${code}m${s}\x1b[0m` : s;
+const cOut = (code: string, s: string): string =>
+  USE_COLOR_STDOUT ? `\x1b[${code}m${s}\x1b[0m` : s;
+export const dim = (s: string): string => c("2", s);
+export const bold = (s: string): string => c("1", s);
+const cyan = (s: string): string => c("36", s);
+const green = (s: string): string => c("32", s);
+export const red = (s: string): string => c("31", s);
+export const boldOut = (s: string): string => cOut("1", s);
+const cyanOut = (s: string): string => cOut("36", s);
+export const greenOut = (s: string): string => cOut("32", s);
+export const dimOut = (s: string): string => cOut("2", s);
+
+export const SYM = USE_COLOR
+  ? { bullet: "●", cont: "⎿", check: "✓", cross: "✗", rule: "━", ellip: "…" }
+  : {
+      bullet: "*",
+      cont: "  >",
+      check: "ok",
+      cross: "FAIL",
+      rule: "=",
+      ellip: "...",
+    };
+
+export const SYM_OUT = USE_COLOR_STDOUT ? { bullet: "●" } : { bullet: "*" };
+
+type AssistantBlock = {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: unknown;
+  id?: string;
+};
+type UserBlock = {
+  type: string;
+  content?: unknown;
+  is_error?: boolean;
+  tool_use_id?: string;
+};
+export type StreamJson =
+  | { type: "assistant"; message?: { content?: AssistantBlock[] } }
+  | { type: "user"; message?: { content?: UserBlock[] } }
+  | { type: "system"; subtype?: string; [k: string]: unknown }
+  | { type: "result"; result?: string; is_error?: boolean }
+  | { type: string; [k: string]: unknown };
+
+export type ToolTrack = { name: string; startedAt: number };
+
+export function renderEvent(
+  ev: StreamJson,
+  toolMap: Map<string, ToolTrack>
+): void {
+  switch (ev.type) {
+    case "system": {
+      const sub = (ev as { subtype?: string }).subtype;
+      if (sub === "init") {
+        const model = (ev as { model?: string }).model ?? "?";
+        const cwd = (ev as { cwd?: string }).cwd ?? "?";
+        process.stderr.write(
+          `${dim("───")} ${bold("init")} ${dim(`model=${model} cwd=${cwd}`)}\n`
+        );
+      }
+      return;
+    }
+    case "assistant": {
+      const content =
+        (ev as { message?: { content?: AssistantBlock[] } }).message?.content ??
+        [];
+      for (const block of content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          const lines = block.text.split("\n");
+          const formatted = lines
+            .map((l, idx) =>
+              idx === 0 ? `${boldOut(cyanOut(SYM_OUT.bullet))} ${l}` : `  ${l}`
+            )
+            .join("\r\n");
+          process.stdout.write(formatted + "\r\n\n");
+        } else if (block.type === "thinking") {
+          process.stderr.write(
+            `${dim(SYM.bullet + " thinking" + SYM.ellip)}\n`
+          );
+        } else if (block.type === "tool_use") {
+          const name = block.name ?? "?";
+          const preview = previewInput(name, block.input);
+          if (block.id) {
+            toolMap.set(block.id, { name, startedAt: Date.now() });
+          }
+          process.stderr.write(
+            `${cyan(SYM.bullet)} ${bold(name)} ${dim(preview)}\n`
+          );
+        }
+      }
+      return;
+    }
+    case "user": {
+      const content =
+        (ev as { message?: { content?: UserBlock[] } }).message?.content ?? [];
+      for (const block of content) {
+        if (block.type !== "tool_result") continue;
+        const text = stringifyToolResult(block.content);
+        const tracked = block.tool_use_id
+          ? toolMap.get(block.tool_use_id)
+          : undefined;
+        const toolName = tracked?.name ?? "tool";
+        const elapsed = tracked ? ` (${Date.now() - tracked.startedAt}ms)` : "";
+        if (block.tool_use_id) toolMap.delete(block.tool_use_id);
+
+        if (block.is_error) {
+          const snippet = text
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, TOOL_ERROR_PREVIEW);
+          process.stderr.write(
+            `${dim(SYM.cont)} ${red(SYM.cross)} ${bold(toolName)}${red(" failed")}\n  ${red(snippet)}${text.length > snippet.length ? " " + SYM.ellip : ""}\n`
+          );
+        } else {
+          const snippet = text
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, TOOL_RESULT_PREVIEW);
+          process.stderr.write(
+            `${dim(SYM.cont)} ${green(SYM.check)} ${bold(toolName)}${dim(elapsed)} ${dim(snippet)}${text.length > snippet.length ? " " + SYM.ellip : ""}\n`
+          );
+        }
+      }
+      return;
+    }
+    case "result": {
+      const isError = (ev as { is_error?: boolean }).is_error;
+      if (isError)
+        process.stderr.write(`${red(SYM.bullet + " result errored")}\n`);
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+function previewInput(toolName: string, input: unknown): string {
+  if (input == null || typeof input !== "object") return "";
+  const obj = input as Record<string, unknown>;
+  // Pick the most informative field per tool.
+  const keyOrder: Record<string, string[]> = {
+    Bash: ["command"],
+    Edit: ["file_path"],
+    Write: ["file_path"],
+    Read: ["file_path"],
+    Glob: ["pattern", "path"],
+    Grep: ["pattern", "path"],
+    TodoWrite: [],
+  };
+  const keys = keyOrder[toolName] ?? Object.keys(obj).slice(0, 2);
+  const parts: string[] = [];
+  for (const k of keys) {
+    const v = obj[k];
+    if (v == null) continue;
+    const s = typeof v === "string" ? v : JSON.stringify(v);
+    parts.push(`${k}=${truncate(s, TOOL_INPUT_PREVIEW)}`);
+  }
+  return parts.join(" ");
+}
+
+function stringifyToolResult(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c) => {
+        if (typeof c === "string") return c;
+        if (c && typeof c === "object" && "text" in c)
+          return String((c as { text: unknown }).text ?? "");
+        return JSON.stringify(c);
+      })
+      .join("\n");
+  }
+  return JSON.stringify(content ?? "");
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + SYM.ellip;
+}

--- a/packages/core/templates/afk.md
+++ b/packages/core/templates/afk.md
@@ -11,3 +11,5 @@
 </inputs>
 
 @include:prompt.md
+
+@include:playbook-common.md

--- a/packages/core/templates/ghafk.md
+++ b/packages/core/templates/ghafk.md
@@ -19,3 +19,5 @@ Read that file with `Read` (use `offset`/`limit` if it is large) to get bodies a
 </issues-full-file>
 
 @include:ghprompt.md
+
+@include:playbook-common.md

--- a/packages/core/templates/ghprompt.md
+++ b/packages/core/templates/ghprompt.md
@@ -9,62 +9,10 @@ You will work on the AFK issues only, not the HITL ones. Label filtering uses th
 
 You've also been passed a file containing the last few commits. Review these to understand what work has been done.
 
-If all AFK tasks are complete, output <promise>NO MORE TASKS</promise>.
-
-# TASK SELECTION
-
-Pick the next task. Prioritize tasks in this order:
-
-1. Critical bugfixes
-2. Development infrastructure
-
-Getting development infrastructure like tests and types and dev scripts ready is an important precursor to building features.
-
-3. Tracer bullets for new features
-
-Tracer bullets are small slices of functionality that go through all layers of the system, allowing you to test and validate your approach early. This helps in identifying potential issues and ensures that the overall architecture is sound before investing significant time in development.
-
-TL;DR - build a tiny, end-to-end slice of the feature first, then expand it out.
-
-4. Polish and quick wins
-5. Refactors
-
-# EXPLORATION
-
-Explore the repo.
-
-# IMPLEMENTATION
-
-Complete the task.
-
-# FEEDBACK LOOPS
-
-Before committing, run the feedback loops:
-
-### Frontend / Node
-
-- `pnpm run test` to run the tests
-- `pnpm run typecheck` to run the type checker
-
-### Backend / Dotnet
-
-- `dotnet test` to run the tests
-- `dotnet build` to type-check
-
-# COMMIT
-
-Make a single `git commit -am` with a short message:
-
-- Subject line (≤72 chars): what changed
-- Optional body (≤3 bullets): key decision, blocker for next iteration
-- No file lists (git tracks them), no `Co-Authored-By`
+If all AFK tasks are complete, output `<promise>NO MORE TASKS</promise>`.
 
 # THE ISSUE
 
 If the task is complete, close the original GitHub issue.
 
 If the task is not complete, leave a comment on the GitHub issue with what was done.
-
-# FINAL RULES
-
-ONLY WORK ON A SINGLE TASK.

--- a/packages/core/templates/playbook-common.md
+++ b/packages/core/templates/playbook-common.md
@@ -1,0 +1,64 @@
+# TASK SELECTION
+
+Pick the next task. Prioritize tasks in this order:
+
+1. Critical bugfixes
+2. Development infrastructure
+
+Getting development infrastructure like tests and types and dev scripts ready is an important precursor to building features.
+
+3. Tracer bullets for new features
+
+Tracer bullets are small slices of functionality that go through all layers of the system, allowing you to test and validate your approach early. This helps in identifying potential issues and ensures that the overall architecture is sound before investing significant time in development.
+
+TL;DR - build a tiny, end-to-end slice of the feature first, then expand it out.
+
+4. Polish and quick wins
+5. Refactors
+
+# EXPLORATION
+
+Explore the repo.
+
+# IMPLEMENTATION
+
+Complete the task.
+
+# FEEDBACK LOOPS
+
+Before committing, run the feedback loops:
+
+### Frontend / Node
+
+- `pnpm run test` to run the tests
+- `pnpm run typecheck` to run the type checker
+
+### Backend / Dotnet
+
+- `dotnet test` to run the tests
+- `dotnet build` to type-check
+
+**If `dotnet test` or `dotnet build` fails with MSB3248** ("Could not resolve assembly reference" / "file is corrupt") — this is a known virtiofs/9p I/O quirk when the repo is mounted from the Windows host. It is NOT a code defect. Do not defer verification. Re-run with build outputs redirected to `/tmp` and parallelism disabled:
+
+```bash
+dotnet test <path-to-test-csproj> \
+  -m:1 \
+  /p:UseSharedCompilation=false \
+  /p:BuildInParallel=false \
+  /p:BaseIntermediateOutputPath=/tmp/ralph-obj/$(basename <path-to-test-csproj> .csproj)/ \
+  /p:BaseOutputPath=/tmp/ralph-bin/$(basename <path-to-test-csproj> .csproj)/
+```
+
+Only if that second attempt also fails may you defer and record the blocker in the commit message.
+
+# COMMIT
+
+Make a single `git commit -am` with a short message:
+
+- Subject line (≤72 chars): what changed
+- Optional body (≤3 bullets): key decision, blocker for next iteration
+- No file lists (git tracks them), no `Co-Authored-By`
+
+# FINAL RULES
+
+ONLY WORK ON A SINGLE TASK.

--- a/packages/core/templates/prompt.md
+++ b/packages/core/templates/prompt.md
@@ -1,80 +1,13 @@
-# ISSUES
+# PLAN / PRD
 
-GitHub issues are provided at start of context. Parse it to get open issues with their bodies and comments.
+The plan and PRD are provided in the `<inputs>` block at the start of context — conventionally the paths to a plan file and a PRD file. `Read` them to get the work.
 
-You will work on the AFK issues only, not the HITL ones.
+You've also been passed the last few commits in `<commits>`. Review them to understand what work has already been done.
 
-You've also been passed a file containing the last few commits. Review these to understand what work has been done.
+Work through the plan/PRD tasks. If all of them are complete, output `<promise>NO MORE TASKS</promise>`.
 
-If all AFK tasks are complete, output <promise>NO MORE TASKS</promise>.
+# RECORDING PROGRESS
 
-# TASK SELECTION
+When a task is complete, record the outcome in your commit body, and update the plan file's status if it tracks one.
 
-Pick the next task. Prioritize tasks in this order:
-
-1. Critical bugfixes
-2. Development infrastructure
-
-Getting development infrastructure like tests and types and dev scripts ready is an important precursor to building features.
-
-3. Tracer bullets for new features
-
-Tracer bullets are small slices of functionality that go through all layers of the system, allowing you to test and validate your approach early. This helps in identifying potential issues and ensures that the overall architecture is sound before investing significant time in development.
-
-TL;DR - build a tiny, end-to-end slice of the feature first, then expand it out.
-
-4. Polish and quick wins
-5. Refactors
-
-# EXPLORATION
-
-Explore the repo.
-
-# IMPLEMENTATION
-
-Complete the task.
-
-# FEEDBACK LOOPS
-
-Before committing, run the feedback loops:
-
-### Frontend / Node
-
-- `pnpm run test` to run the tests
-- `pnpm run typecheck` to run the type checker
-
-### Backend / Dotnet
-
-- `dotnet test` to run the tests
-- `dotnet build` to type-check
-
-**If `dotnet test` or `dotnet build` fails with MSB3248** ("Could not resolve assembly reference" / "file is corrupt") — this is a known virtiofs/9p I/O quirk when the repo is mounted from the Windows host. It is NOT a code defect. Do not defer verification. Re-run with build outputs redirected to `/tmp` and parallelism disabled:
-
-```bash
-dotnet test <path-to-test-csproj> \
-  -m:1 \
-  /p:UseSharedCompilation=false \
-  /p:BuildInParallel=false \
-  /p:BaseIntermediateOutputPath=/tmp/ralph-obj/$(basename <path-to-test-csproj> .csproj)/ \
-  /p:BaseOutputPath=/tmp/ralph-bin/$(basename <path-to-test-csproj> .csproj)/
-```
-
-Only if that second attempt also fails may you defer and record the blocker in the commit message.
-
-# COMMIT
-
-Make a single `git commit -am` with a short message:
-
-- Subject line (≤72 chars): what changed
-- Optional body (≤3 bullets): key decision, blocker for next iteration
-- No file lists (git tracks them), no `Co-Authored-By`
-
-# THE ISSUE
-
-If the task is complete, close the original GitHub issue.
-
-If the task is not complete, leave a comment on the GitHub issue with what was done.
-
-# FINAL RULES
-
-ONLY WORK ON A SINGLE TASK.
+If a task is not complete, record the blocker in the commit body so the next iteration can pick up where you left off.


### PR DESCRIPTION
This PR prepares the repository for open-source readiness and updates the AFK/GHAFK execution path to use a shared run-bin/stage pipeline.

### What changed
- Add OSS project hygiene and automation assets:
  - CODE_OF_CONDUCT, LICENSE, SECURITY, issue/PR templates
  - CI and Dependabot configuration under .github
  - README/CONTRIBUTING/QUICKSTART/docs updates and package metadata polish
- Refactor core execution flow:
  - Introduce `run-bin` and `stream-render` helpers
  - Adjust stage wiring in `main`, `gh-main`, `loop`, and `stages`
  - Update `runner` internals and add docker.sock mount warning behavior
- Consolidate template playbooks:
  - Add shared `playbook-common.md`
  - Retarget/clean up plan and PRD playbook composition across `afk`, `ghafk`, `prompt`, and `ghprompt`

### Why
- Make the repo production-ready for public collaboration and security/compliance expectations.
- Reduce duplication in stage/playbook plumbing to simplify maintenance and future changes.

### Notes for reviewers
- This is a broad branch that combines OSS readiness work with core runtime and template refactors.
- Recommend reviewing in commit order for easier context:
  1. `chore: prepare repo for open-source release`
  2. `fix(core): warn on docker.sock mount; refactor bin/runner internals`
  3. `fix: retarget the plan/PRD playbook and dedup the shared playbook body`