### PR TITLE
Release v0.6.2

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daonhan/ralph",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "CLI for the ralph AFK loop (ralph-afk, ralph-ghafk).",
   "type": "module",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daonhan/ralph-core",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Claude Code AFK orchestration: iteration loop, docker runner, template renderer.",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/__tests__/loop.test.ts
+++ b/packages/core/src/__tests__/loop.test.ts
@@ -149,6 +149,16 @@ describe("runLoop", () => {
     expect(stderr).toContain("ralph-afk 9.9.9 (core ");
   });
 
+  it("uses the bin name in the wake-lock reason", async () => {
+    const dirs = makeDirs();
+    roots.push(dirs.root);
+    mocks.runStage.mockResolvedValue(sentinel);
+
+    await runLoop(loopOptions(dirs, { bin: "ralph-ghafk" }));
+
+    expect(mocks.acquire).toHaveBeenCalledWith({ reason: "ralph-ghafk loop" });
+  });
+
   it("logs terminal stage failure and continues with the next iteration", async () => {
     const dirs = makeDirs();
     roots.push(dirs.root);

--- a/packages/core/src/__tests__/loop.test.ts
+++ b/packages/core/src/__tests__/loop.test.ts
@@ -134,6 +134,21 @@ describe("runLoop", () => {
     expect(mocks.notifyComplete).toHaveBeenCalledWith(1, true);
   });
 
+  it("prints the cli + core version banner at loop init", async () => {
+    const dirs = makeDirs();
+    roots.push(dirs.root);
+    mocks.runStage.mockResolvedValue(sentinel);
+
+    await runLoop(loopOptions(dirs, { bin: "ralph-afk", cliVersion: "9.9.9" }));
+
+    const stderr = (
+      process.stderr.write as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls
+      .map((c) => String(c[0]))
+      .join("");
+    expect(stderr).toContain("ralph-afk 9.9.9 (core ");
+  });
+
   it("logs terminal stage failure and continues with the next iteration", async () => {
     const dirs = makeDirs();
     roots.push(dirs.root);

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname, join, posix } from "node:path";
 
+import { readCoreVersion } from "./cli-help.js";
 import { acquire, type Releaser } from "./keepalive.js";
 import { notifyComplete, notifyError } from "./notify.js";
 import { renderTemplate } from "./render.js";
@@ -46,6 +47,10 @@ export type LoopOptions = {
   maxRetries?: number;
   /** When true, fire OS notification + bell on loop terminal events. Default: false. */
   notify?: boolean;
+  /** Bin name for the init-time version banner (e.g. "ralph-afk"). */
+  bin?: string;
+  /** CLI version for the init-time version banner. */
+  cliVersion?: string;
 };
 
 export async function runLoop(opts: LoopOptions): Promise<void> {
@@ -59,7 +64,14 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
     noKeepAlive = false,
     maxRetries = DEFAULT_MAX_RETRIES,
     notify = false,
+    bin = "ralph",
+    cliVersion = "?",
   } = opts;
+
+  const versionLine = `${bin} ${cliVersion} (core ${readCoreVersion()})`;
+  process.stderr.write(
+    `${USE_COLOR ? `${dim("━━━")} ${bold(versionLine)} ${dim("━━━")}` : `== ${versionLine} ==`}\n`
+  );
 
   const releaser: Releaser = noKeepAlive
     ? { release: () => {} }

--- a/packages/core/src/loop.ts
+++ b/packages/core/src/loop.ts
@@ -75,7 +75,7 @@ export async function runLoop(opts: LoopOptions): Promise<void> {
 
   const releaser: Releaser = noKeepAlive
     ? { release: () => {} }
-    : acquire({ reason: "ralph-afk loop" });
+    : acquire({ reason: `${bin} loop` });
   const stageAbort = new AbortController();
 
   // Single release path: signal handlers and the finally below all funnel

--- a/packages/core/src/run-bin.ts
+++ b/packages/core/src/run-bin.ts
@@ -101,5 +101,7 @@ export async function runBin(argv: string[], cfg: RunBinConfig): Promise<void> {
     noKeepAlive: flags.noKeepAlive,
     maxRetries: flags.maxRetries,
     notify: flags.notify,
+    bin: cfg.bin,
+    cliVersion: cfg.cliVersion,
   });
 }


### PR DESCRIPTION
This prepares the v0.6.2 release.

Summary:
- bump `@daonhan/ralph` and `@daonhan/ralph-core` from 0.6.1 to 0.6.2
- print the CLI and core versions at loop startup so each AFK run and detached log shows the running version immediately
- thread the bin name and CLI version through `runBin` into `runLoop`
- add coverage for the new loop banner behavior

Why:
- the release bump publishes the next CLI/core version
- the startup banner makes it easier to confirm exactly which build is running when diagnosing local or detached executions