### PR TITLE
Fix husky pre-commit hook setup and prepare script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
+#!/usr/bin/env sh
 pnpm exec lint-staged
 pnpm typecheck

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
+set -e
 pnpm exec lint-staged
 pnpm typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,9 @@ Smoke scripts in `scripts/` (import the built `dist/`, so run after `pnpm -r bui
 
 ## Pre-commit hook
 
-`pnpm install` runs the root `"prepare": "husky"` script, which installs the git
-hooks. On commit, [`.husky/pre-commit`](./.husky/pre-commit) runs:
+`pnpm install` runs the root `"prepare": "husky || git config core.hooksPath .husky"`
+script, which installs the git hooks or falls back to setting `core.hooksPath`.
+On commit, [`.husky/pre-commit`](./.husky/pre-commit) runs:
 
 ```bash
 pnpm exec lint-staged    # prettier --ignore-unknown --write on staged files

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -358,7 +358,7 @@ pnpm --filter @daonhan/ralph-core test
 pnpm test
 ```
 
-The pre-commit hook ([`../.husky/pre-commit`](../.husky/pre-commit)) runs `pnpm exec lint-staged` (Prettier `--write` on staged files) then `pnpm typecheck`.
+The pre-commit hook ([`../.husky/pre-commit`](../.husky/pre-commit)) runs `pnpm exec lint-staged` (Prettier `--write` on staged files) then `pnpm typecheck`. The root `prepare` script is `husky || git config core.hooksPath .husky` so installs still work if Husky does not self-initialize.
 
 Build the sandbox image locally from [`../packages/core/templates/Dockerfile`](../packages/core/templates/Dockerfile) (`node:22-bookworm` + git/curl/jq + .NET SDK 10 + `gh` + Claude Code CLI; base `node` user renamed to `agent` UID 1000; `safe.directory=*` global; `WORKDIR /home/agent/workspace`; `ENTRYPOINT []`, `CMD ["claude"]`):
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typecheck": "pnpm -r run typecheck",
     "test": "node --test scripts/runner-floating-ref.test.mjs scripts/release-please-config.test.mjs scripts/update-status-table.test.mjs",
     "publish-all": "pnpm -r publish --access public --no-git-checks",
-    "prepare": "husky"
+    "prepare": "husky || git config core.hooksPath .husky"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",


### PR DESCRIPTION
## Summary

Fix issues with husky pre-commit hooks not being set up correctly during package installation and ensure proper execution permissions on hook scripts.

## Changes

- Update prepare script to ensure husky hooks are set correctly
- Fix pre-commit script execution permissions

## Related

Fixes issues with release-please manifest anchor configuration and pre-commit hook initialization.