### PR TITLE
Complete Python sandbox smoke contracts

### DIFF
--- a/.codex/AGENT.md
+++ b/.codex/AGENT.md
@@ -1,0 +1,70 @@
+# AGENT.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # AGENTS.md
 
-This file provides guidance to Codex (Codex.ai/code) when working with code in this repository. See [.Codex/AGENTS.md](.Codex/AGENTS.md) (behavioral rules).
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository. See [.codex/AGENT.md](.codex/AGENT.md) (behavioral rules).
 
 ## What this repo is
 
-Ralph is a Node/TypeScript harness that drives the Codex CLI against a target repository in an iterating implementer → reviewer loop, inside an ephemeral Docker container (`ralph-sandbox`). It ships as a pnpm monorepo with two npm packages:
+Ralph is a Node/TypeScript harness that drives the Claude Code CLI against a target repository in an iterating implementer → reviewer loop, inside an ephemeral Docker container (`ralph-sandbox`). It ships as a pnpm monorepo with two npm packages:
 
 - `@daonhan/ralph-core` (`packages/core`) — library: loop driver, docker runner, template renderer, stage registry. ESM, TS-compiled to `dist/`.
 - `@daonhan/ralph` (`apps/cli`) — CLI exposing `ralph-afk` (plan/PRD loop) and `ralph-ghafk` (GitHub-issue loop) bin entries. Hand-written JS bins, no build step. Depends on `@daonhan/ralph-core` via `workspace:^`.
@@ -45,7 +45,7 @@ ralph-ghafk <iterations>                          # GitHub-issue-driven loop
 ralph-afk --print-config                          # diagnose: print workspace / docker context / image
 ```
 
-Bins also accept `--help` / `-h`. `$RALPH_WORKSPACE` overrides cwd as the bind-mounted target; `$RALPH_IMAGE` overrides the default `docker.io/daonhan/ralph-sandbox:latest`; `$RALPH_DOCKER_CONTEXT` is the `docker build` fallback context (default: bundled `@daonhan/ralph-core` dir, which ships the `Dockerfile`). Other env knobs: `$RALPH_RESULT_GRACE_MS` (post-result grace timer, default `30000`, `0` disables), `$RALPH_DOCKER_SOCK=0` (disable the docker-socket mount), `$RALPH_DOCKER_SOCK_PATH` (explicit socket path), `$RALPH_MODEL` (pass-through `--model <value>` to the in-container Codex CLI; unset = sandbox CLI default), `$NO_COLOR` / `$TERM=dumb` (disable ANSI). Bins also accept `--version`/`-V`, `--no-keep-alive`, `--max-retries <N>`, `--detach`, `--log <path>`, `--notify` (see README "Running AFK").
+Bins also accept `--help` / `-h`. `$RALPH_WORKSPACE` overrides cwd as the bind-mounted target; `$RALPH_IMAGE` overrides the default `docker.io/daonhan/ralph-sandbox:latest`; `$RALPH_DOCKER_CONTEXT` is the `docker build` fallback context (default: bundled `@daonhan/ralph-core` dir, whose `templates/` subdirectory ships the `Dockerfile`; a context-root `Dockerfile` is a legacy fallback). Other env knobs: `$RALPH_RESULT_GRACE_MS` (post-result grace timer, default `30000`, `0` disables), `$RALPH_DOCKER_SOCK=0` (disable the docker-socket mount), `$RALPH_DOCKER_SOCK_PATH` (explicit socket path), `$RALPH_MODEL` (pass-through `--model <value>` to the in-container `claude` CLI; unset or empty/whitespace = sandbox CLI default), `$NO_COLOR` / `$TERM=dumb` (disable ANSI). Bins also accept `--version`/`-V`, `--no-keep-alive`, `--max-retries <N>`, `--detach`, `--log <path>`, `--notify` (see README "Running AFK").
 
 ### Building / publishing the sandbox image
 
@@ -63,9 +63,9 @@ The core library is ~12 source files in `packages/core/src/` (plus a `__tests__/
 2. **`loop.ts`** (`runLoop`) — drives the iteration. For each iteration, walks the stage chain. **First stage is the gate**: its `result` string is sentinel-checked for `<promise>NO MORE TASKS</promise>` and the loop exits early on hit. Subsequent stages always run after a non-sentinel gate. Calls `ensureImage` once before the loop.
 3. **`render.ts`** (`renderTemplate`) — expands the five template tags below before each stage runs. Synchronous, uses host `execSync` for shell tags.
 4. **`runner.ts`** (`ensureImage`, `runStage`) — docker plumbing.
-   - `ensureImage`: `docker image inspect` → `docker pull` → `docker build` (fallback). Build fallback only runs if pull fails AND `$RALPH_DOCKER_CONTEXT/Dockerfile` exists.
-   - `runStage`: writes the rendered prompt to `<workspaceDir>/.ralph-tmp/.run-<pid>-<iter>-<ts>.md`, spawns `docker run --rm -i … Codex --verbose --print --output-format stream-json --permission-mode <mode> "Read the full instructions from ./.ralph-tmp/<file> …"`. Streams NDJSON from stdout, captures the `result` event's payload as the stage return value. Tempfile cleaned in `finally`.
-5. **`stages.ts`** — three named stages (`implementer`, `ghafkImplementer`, `reviewer`), each pairing a template filename with a Codex `permissionMode` (always `bypassPermissions` — AFK requires non-interactive bash/edit approval; blast radius bounded to the workspace mount).
+   - `ensureImage`: `docker image inspect` → `docker pull` → `docker build` (fallback). Build fallback only runs if pull fails and the resolved Dockerfile exists at `$RALPH_DOCKER_CONTEXT/templates/Dockerfile` (preferred) or `$RALPH_DOCKER_CONTEXT/Dockerfile` (legacy).
+   - `runStage`: writes the rendered prompt to `<workspaceDir>/.ralph-tmp/.run-<pid>-<iter>-<ts>.md`, spawns `docker run --rm -i … claude --verbose --print --output-format stream-json --permission-mode <mode> "Read the full instructions from ./.ralph-tmp/<file> …"`. Streams NDJSON from stdout, captures the `result` event's payload as the stage return value. Tempfile cleaned in `finally`.
+5. **`stages.ts`** — three named stages (`implementer`, `ghafkImplementer`, `reviewer`), each pairing a template filename with a Claude Code `permissionMode` (always `bypassPermissions` — AFK requires non-interactive bash/edit approval). With the default Docker socket mount, the sandbox has root-equivalent access to the host Docker daemon; when the socket is disabled, host writes are limited to the workspace and writable Claude credential mounts (plus the ephemeral container filesystem).
 6. **AFK machinery** — `cli-help.ts` (flag parsing: `--detach` / `--notify` / `--max-retries` / `--no-keep-alive` / `--log` / `--version` / `--print-config`), `retry.ts` (`withRetries`, default 3 + exponential backoff), `keepalive.ts` (OS wake-lock acquire/release), `detach.ts` (fork-and-exit background run), `notify.ts` (OS toast + bell). `loop.ts` wires these in and handles `SIGINT`→exit 130 / `SIGTERM`→exit 143 by aborting the active stage via an `AbortController`. Full runtime model: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ### Loop topology
@@ -99,17 +99,17 @@ Every run writes to `<workspaceDir>/.ralph-tmp/` on the host (gitignored): the r
 
 `runStage` reads `process.env.HOME || USERPROFILE` and bind-mounts (read-only for gh) if present:
 
-- `~/.Codex` → `/home/agent/.Codex`
-- `~/.Codex.json` → `/home/agent/.Codex.json`
+- `~/.claude` → `/home/agent/.claude`
+- `~/.claude.json` → `/home/agent/.claude.json`
 - `~/.config/gh` → `/home/agent/.config/gh:ro`
 
 `runStage` also injects git env vars (`GIT_CONFIG_COUNT/KEY_0=safe.directory/VALUE_0=*`) so git trusts the bind-mounted workspace, and — **by default** — bind-mounts the host Docker socket (`-v <sock>:/var/run/docker.sock` + a `--group-add` fixup, via `resolveDockerSocketMount`) so Testcontainers inside the sandbox can spawn sibling containers. That grants the sandbox root-equivalent host Docker access; disable with `RALPH_DOCKER_SOCK=0`, or set an explicit path with `RALPH_DOCKER_SOCK_PATH`.
 
-**Same-shell rule:** these paths resolve against the shell that invoked the bin. PowerShell `$HOME` (`C:\Users\<you>`) and WSL `$HOME` (`/home/<you>`) are separate stores — don't mix. `Codex /login` and `gh auth login` must be run from a shell context that matches your eventual invocation context (or copied across — see README "Windows + WSL: credentials").
+**Same-shell rule:** these paths resolve against the shell that invoked the bin. PowerShell `$HOME` (`C:\Users\<you>`) and WSL `$HOME` (`/home/<you>`) are separate stores — don't mix. `claude /login` and `gh auth login` must be run from a shell context that matches your eventual invocation context (or copied across — see README "Windows + WSL: credentials").
 
 ### Sandbox image
 
-`packages/core/templates/Dockerfile`. Node 22 + .NET SDK 10 + `gh` + `jq` + `git` + Codex CLI. User `agent` (UID 1000, renamed from base image's `node`). `safe.directory='*'` globally configured to tolerate bind-mount UID mismatch on Windows.
+`packages/core/templates/Dockerfile`. Node 22 + Debian Bookworm Python 3.11 as `python`/`python3` + `python -m venv` + `uv`/`uvx` 0.11.28 + .NET SDK 10 + `gh` + `jq` + `git` + Claude Code CLI. User `agent` (UID 1000, renamed from base image's `node`). `safe.directory='*'` globally configured to tolerate bind-mount UID mismatch on Windows.
 
 ## Conventions to preserve
 
@@ -129,7 +129,7 @@ Every run writes to `<workspaceDir>/.ralph-tmp/` on the host (gitignored): the r
 
 ## Behavioral
 
-Apply `.Codex/AGENTS.md` (think first, simplicity, surgical changes, goal-driven). Make only changes the user asked for; match existing style; prefer smallest correct change; push back on over-engineering; state a brief plan + success criteria for non-trivial work.
+Apply `.codex/AGENT.md` (think first, simplicity, surgical changes, goal-driven). Make only changes the user asked for; match existing style; prefer smallest correct change; push back on over-engineering; state a brief plan + success criteria for non-trivial work.
 
 ## Imported Claude Cowork project instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,145 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository. See [.Codex/AGENTS.md](.Codex/AGENTS.md) (behavioral rules).
+
+## What this repo is
+
+Ralph is a Node/TypeScript harness that drives the Codex CLI against a target repository in an iterating implementer → reviewer loop, inside an ephemeral Docker container (`ralph-sandbox`). It ships as a pnpm monorepo with two npm packages:
+
+- `@daonhan/ralph-core` (`packages/core`) — library: loop driver, docker runner, template renderer, stage registry. ESM, TS-compiled to `dist/`.
+- `@daonhan/ralph` (`apps/cli`) — CLI exposing `ralph-afk` (plan/PRD loop) and `ralph-ghafk` (GitHub-issue loop) bin entries. Hand-written JS bins, no build step. Depends on `@daonhan/ralph-core` via `workspace:^`.
+
+## Commands
+
+All commands run from the repo root unless noted. Node ≥20, pnpm ≥9.
+
+```bash
+pnpm install                 # link workspace, hoist devDeps
+pnpm -r build                # compile packages/core/dist (tsc -p tsconfig.json)
+pnpm -r typecheck            # tsc --noEmit across workspace
+pnpm -r clean                # rm packages/core/dist
+pnpm publish-all             # pnpm -r publish --access public --no-git-checks
+```
+
+Verification = `pnpm -r typecheck` + `pnpm -r test` (`packages/core` runs `vitest run`; `apps/cli` has no tests) + root `pnpm test` (`node --test` over `scripts/*.test.mjs`). A husky pre-commit hook runs `lint-staged` (`prettier --ignore-unknown --write` on staged files) then `pnpm typecheck`. Full contributor guide: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Per-package: `pnpm --filter @daonhan/ralph-core build` (only core has a build).
+
+### Smoke-test the published artifacts locally
+
+```bash
+pnpm -r build
+(cd packages/core && pnpm pack --pack-destination /tmp/ralph-packs)
+(cd apps/cli      && pnpm pack --pack-destination /tmp/ralph-packs)
+npm i -g /tmp/ralph-packs/daonhan-ralph-core-*.tgz /tmp/ralph-packs/daonhan-ralph-*.tgz
+ralph-afk          # → prints usage
+```
+
+`pnpm link --global` is brittle inside this workspace (pnpm 9 rewrites the dependent's manifest) — use the pack-then-install path.
+
+### Running the bins against a target workspace
+
+```bash
+ralph-afk "<plan-and-prd>" <iterations>          # plan/PRD-driven loop
+ralph-ghafk <iterations>                          # GitHub-issue-driven loop
+ralph-afk --print-config                          # diagnose: print workspace / docker context / image
+```
+
+Bins also accept `--help` / `-h`. `$RALPH_WORKSPACE` overrides cwd as the bind-mounted target; `$RALPH_IMAGE` overrides the default `docker.io/daonhan/ralph-sandbox:latest`; `$RALPH_DOCKER_CONTEXT` is the `docker build` fallback context (default: bundled `@daonhan/ralph-core` dir, which ships the `Dockerfile`). Other env knobs: `$RALPH_RESULT_GRACE_MS` (post-result grace timer, default `30000`, `0` disables), `$RALPH_DOCKER_SOCK=0` (disable the docker-socket mount), `$RALPH_DOCKER_SOCK_PATH` (explicit socket path), `$RALPH_MODEL` (pass-through `--model <value>` to the in-container Codex CLI; unset = sandbox CLI default), `$NO_COLOR` / `$TERM=dumb` (disable ANSI). Bins also accept `--version`/`-V`, `--no-keep-alive`, `--max-retries <N>`, `--detach`, `--log <path>`, `--notify` (see README "Running AFK").
+
+### Building / publishing the sandbox image
+
+```bash
+docker build -t docker.io/daonhan/ralph-sandbox:latest -f packages/core/templates/Dockerfile .
+```
+
+CI in `.github/workflows/publish-image.yml` builds + pushes a single-arch `linux/amd64` image on `workflow_dispatch`, a `ralph-sandbox-v*` tag (release-please primary; also enriches the GitHub Release with the sha256 digest + SBOM + cosign attestation), or a legacy `image-v*` tag (shim). npm + image releases are automated via release-please — see [RELEASING.md](RELEASING.md).
+
+## Architecture
+
+The core library is ~12 source files in `packages/core/src/` (plus a `__tests__/` vitest suite). Read the loop spine in order to understand the system:
+
+1. **`main.ts` / `gh-main.ts`** — thin bin entrypoints. Each just calls `runBin` (`run-bin.ts`) with its stage chain + a `takesInputArg` flag. `runBin` parses flags via `cli-help.ts`, resolves `workspaceDir` / `ralphDir` / `packageDir` from env vars, then calls `runLoop`.
+2. **`loop.ts`** (`runLoop`) — drives the iteration. For each iteration, walks the stage chain. **First stage is the gate**: its `result` string is sentinel-checked for `<promise>NO MORE TASKS</promise>` and the loop exits early on hit. Subsequent stages always run after a non-sentinel gate. Calls `ensureImage` once before the loop.
+3. **`render.ts`** (`renderTemplate`) — expands the five template tags below before each stage runs. Synchronous, uses host `execSync` for shell tags.
+4. **`runner.ts`** (`ensureImage`, `runStage`) — docker plumbing.
+   - `ensureImage`: `docker image inspect` → `docker pull` → `docker build` (fallback). Build fallback only runs if pull fails AND `$RALPH_DOCKER_CONTEXT/Dockerfile` exists.
+   - `runStage`: writes the rendered prompt to `<workspaceDir>/.ralph-tmp/.run-<pid>-<iter>-<ts>.md`, spawns `docker run --rm -i … Codex --verbose --print --output-format stream-json --permission-mode <mode> "Read the full instructions from ./.ralph-tmp/<file> …"`. Streams NDJSON from stdout, captures the `result` event's payload as the stage return value. Tempfile cleaned in `finally`.
+5. **`stages.ts`** — three named stages (`implementer`, `ghafkImplementer`, `reviewer`), each pairing a template filename with a Codex `permissionMode` (always `bypassPermissions` — AFK requires non-interactive bash/edit approval; blast radius bounded to the workspace mount).
+6. **AFK machinery** — `cli-help.ts` (flag parsing: `--detach` / `--notify` / `--max-retries` / `--no-keep-alive` / `--log` / `--version` / `--print-config`), `retry.ts` (`withRetries`, default 3 + exponential backoff), `keepalive.ts` (OS wake-lock acquire/release), `detach.ts` (fork-and-exit background run), `notify.ts` (OS toast + bell). `loop.ts` wires these in and handles `SIGINT`→exit 130 / `SIGTERM`→exit 143 by aborting the active stage via an `AbortController`. Full runtime model: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+### Loop topology
+
+```
+ralph-afk   → [STAGES.implementer,        STAGES.reviewer]   inputs = "<plan-and-prd>"
+ralph-ghafk → [STAGES.ghafkImplementer,   STAGES.reviewer]   inputs = ""
+```
+
+Gate = first stage. Reviewer never gates.
+
+### Template renderer (the part most likely to bite you)
+
+Templates live in `packages/core/templates/`. Five tag forms, expanded in this order (`@include` → `@spill` → `!?` → `!` → `{{ INPUTS }}`):
+
+| Tag                  | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@include:<path>`    | Inline a file via `readFileSync`. Path resolved against the template's dir when relative. **No shell**. Used to inject the agent playbooks (`prompt.md`, `ghprompt.md`) into the iteration templates (`afk.md`, `ghafk.md`).                                                                                                                                                                                                                                                   |
+| `@spill[?]:<name>=…` | Run a command, write its stdout to `<spill-dir>/<name>`, and substitute the container-relative path `./.ralph-tmp/spill-…/<name>` into the prompt (the agent `Read`s it). The `?` form writes a fallback string on non-zero exit; `<name>` must be a plain filename (no path separators / `..`). Keeps large outputs (HEAD patch in `review.md`, full issue bodies in `ghafk.md`) out of the prompt. Requires `spillHostDir`/`spillRefPath` (supplied per-stage by `runLoop`). |
+| `` !?`<cmd>          |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |     | <fallback>` `` | Try-shell. `execSync` with stderr suppressed; non-zero exit returns the literal `<fallback>` string. Match order matters: this regex matches before the plain `!` form. Use for cross-platform safety. |
+| `` !`<cmd>` ``       | Plain shell. `execSync` with `cwd = workspaceDir`. Failures throw and abort the iteration.                                                                                                                                                                                                                                                                                                                                                                                     |
+| `{{ INPUTS }}`       | Replaced with the `inputs` string passed to `runLoop`.                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+Shell resolution lives in `resolveShell()` in `render.ts`: Linux/macOS → `/bin/bash`. Windows → walks `$PATH` looking for `bash.exe` (Git for Windows or WSL passthrough), falls back to `cmd.exe`. **Templates should prefer `!?` over `!` for any command that might be unavailable on `cmd.exe`** (e.g. `git log` redirects, `gh issue list`).
+
+### Per-iteration scratch dir
+
+Every run writes to `<workspaceDir>/.ralph-tmp/` on the host (gitignored): the rendered prompt as `.run-<pid>-<iter>-<ts>.md` (cleaned in `finally`, may leak on SIGKILL — safe to delete) a per-stage spill dir `spill-<pid>-<iter>-<stageIdx>-<ts>/` holding `@spill` output (also cleaned in `finally`), and the NDJSON stream log as `logs/<ts>-iter<N>-<stageName>.ndjson` (kept; `--detach` adds `logs/detached-<pid>.log`).
+
+### Credential mounts
+
+`runStage` reads `process.env.HOME || USERPROFILE` and bind-mounts (read-only for gh) if present:
+
+- `~/.Codex` → `/home/agent/.Codex`
+- `~/.Codex.json` → `/home/agent/.Codex.json`
+- `~/.config/gh` → `/home/agent/.config/gh:ro`
+
+`runStage` also injects git env vars (`GIT_CONFIG_COUNT/KEY_0=safe.directory/VALUE_0=*`) so git trusts the bind-mounted workspace, and — **by default** — bind-mounts the host Docker socket (`-v <sock>:/var/run/docker.sock` + a `--group-add` fixup, via `resolveDockerSocketMount`) so Testcontainers inside the sandbox can spawn sibling containers. That grants the sandbox root-equivalent host Docker access; disable with `RALPH_DOCKER_SOCK=0`, or set an explicit path with `RALPH_DOCKER_SOCK_PATH`.
+
+**Same-shell rule:** these paths resolve against the shell that invoked the bin. PowerShell `$HOME` (`C:\Users\<you>`) and WSL `$HOME` (`/home/<you>`) are separate stores — don't mix. `Codex /login` and `gh auth login` must be run from a shell context that matches your eventual invocation context (or copied across — see README "Windows + WSL: credentials").
+
+### Sandbox image
+
+`packages/core/templates/Dockerfile`. Node 22 + .NET SDK 10 + `gh` + `jq` + `git` + Codex CLI. User `agent` (UID 1000, renamed from base image's `node`). `safe.directory='*'` globally configured to tolerate bind-mount UID mismatch on Windows.
+
+## Conventions to preserve
+
+- **ESM only.** Both packages are `"type": "module"`. Relative imports in `packages/core/src/` end in `.js` (compiled output extension, required by `moduleResolution: NodeNext`).
+- **First stage is always the gate.** If you add stages via `STAGES` and wire them into a chain, place gating stages at index 0. The sentinel string `<promise>NO MORE TASKS</promise>` is hardcoded in `loop.ts`.
+- **No build step for `apps/cli`.** Bins are hand-written JS that `import { runAfk } from "@daonhan/ralph-core"`. Don't add TS to `apps/cli` — keep the bin layer flat.
+- **Templates ship in the npm tarball.** `packages/core/package.json` `files` includes `templates/` and `Dockerfile`. Adding a new stage means: (1) extend `STAGES` in `stages.ts`, (2) drop a new `*.md` in `packages/core/templates/`, (3) reference it from the chain in `main.ts` / `gh-main.ts`.
+- **Permission mode is always `bypassPermissions`** for stages running inside `ralph-sandbox` — AFK requires it. Comment in `stages.ts` explains the blast-radius reasoning.
+
+## Files for orientation
+
+- `README.md` — extensive user-facing docs (install paths per OS, first-run setup, troubleshooting). Read for usage/setup questions.
+- `RELEASING.md` — single source of truth for releasing all three components (release-please flow, version policy, required secrets, rollback runbook). `docs/PUBLISHING.md` is a stub pointing here.
+- `CONTRIBUTING.md` — maintainer/contributor guide (dev loop, tests, adding a stage, releasing). `docs/ARCHITECTURE.md` — runtime internals reference.
+- `packages/core/templates/prompt.md` / `ghprompt.md` — agent playbooks. Edit these to change feedback loops or task priority.
+- `packages/core/templates/{afk,ghafk,review}.md` — iteration templates that `@include` the playbooks above.
+
+## Behavioral
+
+Apply `.Codex/AGENTS.md` (think first, simplicity, surgical changes, goal-driven). Make only changes the user asked for; match existing style; prefer smallest correct change; push back on over-engineering; state a brief plan + success criteria for non-trivial work.
+
+## Imported Claude Cowork project instructions
+
+Ralph — Autonomous Claude Code Loop
+Ralph drives Claude Code against a target repository in an iterating implementer → reviewer pipeline, isolated inside a custom Docker image. The harness ships as two npm packages, with thin bash shims that wire host paths + credentials into the CLI.
+
+@daonhan/ralph-core — library: iteration loop, docker runner, template renderer, stage registry. Importable from any Node project.
+@daonhan/ralph — CLI: exposes ralph-afk and ralph-ghafk bin entries. Depends on @daonhan/ralph-core.
+Two AFK entry points (both installed globally after npm i -g @daonhan/ralph):
+
+ralph-afk — plan/PRD-driven loop. Hand it a plan + PRD string; iterates until the agent emits NO MORE TASKS.
+ralph-ghafk — GitHub-issue-driven loop. Pulls open issues with gh issue list and lets the agent pick the next AFK task.
+Convenience shims live at apps/cli/scripts/afk.sh and apps/cli/scripts/ghafk.sh — thin wrappers that fall back to npx @daonhan/ralph if not installed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you just want to _run_ Ralph against your own repo, see [`./README.md`](./REA
 | ------ | ------- | ------------------------------------------------------------- |
 | Node   | ≥ 20    | ESM, `node --test`, `tsc`.                                    |
 | pnpm   | ≥ 9     | Workspace linking. Root pins `packageManager: pnpm@9.12.0`.   |
-| Docker | any     | Running the loop and the `ensure-image` / spill smoke checks. |
+| Docker | any     | Running the loop and the image / `ensure-image` smoke checks. |
 
 `corepack enable` will activate the pinned pnpm automatically.
 
@@ -83,6 +83,10 @@ Note the layered meaning of "test" in this monorepo:
   `packages/core` → `vitest run`; `apps/cli` has no `test` script (skipped).
 - **`pnpm test`** (root) → `node --test`, which discovers `scripts/*.test.mjs`.
 
+The full sandbox-image smoke is intentionally not part of these ordinary test
+commands because it builds an image and, by default, reaches PyPI. Run it explicitly
+for image changes as described in [Verify sandbox image changes](#verify-sandbox-image-changes).
+
 ### What each test covers
 
 Vitest unit tests, `packages/core/src/__tests__/` (pure logic, mocked I/O):
@@ -98,11 +102,12 @@ Vitest unit tests, `packages/core/src/__tests__/` (pure logic, mocked I/O):
 
 Root `node --test`, `scripts/*.test.mjs` (contract + pure-render tests):
 
-| File                             | Covers                                                                       |
-| -------------------------------- | ---------------------------------------------------------------------------- |
-| `release-please-config.test.mjs` | Reproduces release-please path attribution; catches component-scoping drift. |
-| `runner-floating-ref.test.mjs`   | `isFloatingRef` — when `ensureImage` must re-pull vs. short-circuit.         |
-| `update-status-table.test.mjs`   | `renderStatusTable` / `replaceBlock` for the RELEASING.md status block.      |
+| File                             | Covers                                                                                    |
+| -------------------------------- | ----------------------------------------------------------------------------------------- |
+| `release-please-config.test.mjs` | Reproduces release-please path attribution; catches component-scoping drift.              |
+| `runner-floating-ref.test.mjs`   | `isFloatingRef` — when `ensureImage` must re-pull vs. short-circuit.                      |
+| `smoke-image.test.mjs`           | Image-smoke argument parsing, Docker command construction, and failures; no Docker calls. |
+| `update-status-table.test.mjs`   | `renderStatusTable` / `replaceBlock` for the RELEASING.md status block.                   |
 
 Smoke scripts in `scripts/` (import the built `dist/`, so run after `pnpm -r build`):
 
@@ -113,6 +118,40 @@ Smoke scripts in `scripts/` (import the built `dist/`, so run after `pnpm -r bui
 | `smoke-spill-size.mjs`         | Heavy `@spill` output lands in the spill file, not the prompt.                                                    |
 | `smoke-spill-large.mjs`        | A ~200 KB `@spill` payload spills while the prompt keeps only a short ref path.                                   |
 | `ensure-image-integration.mjs` | `ensureImage` against the real `docker` CLI (re-pull / fallback / pinned).                                        |
+| `smoke-image.mjs`              | Builds or accepts a sandbox image, then checks the external Python/user/tooling contract.                         |
+
+### Verify sandbox image changes
+
+Every change to the sandbox image must pass this maintainer smoke before its
+`ralph-sandbox` Release PR is merged and the image is published:
+
+```bash
+pnpm smoke:image
+```
+
+The default command builds `ralph-sandbox:smoke` from
+`packages/core/templates/Dockerfile` with the repository root as its Docker build
+context, then checks the default `agent` user, `python`, `python3`, venv creation,
+pip inside the venv, `uv`, and an `uv` install of the pure-Python `six` package from
+PyPI.
+
+To smoke an already-built release candidate without rebuilding it, pass its tag:
+
+```bash
+pnpm smoke:image -- --image ralph-sandbox:python-tooling
+```
+
+The package-install check requires network access and the command announces when it
+runs. For an offline diagnostic only, skip that check explicitly with
+`--skip-network` (or `RALPH_SMOKE_SKIP_NETWORK=1`):
+
+```bash
+pnpm smoke:image -- --image ralph-sandbox:python-tooling --skip-network
+```
+
+`RALPH_SMOKE_IMAGE=<tag>` is the environment-variable equivalent of `--image`.
+The final pre-publish verification must run the network check; a skipped run is not
+sufficient to release the image.
 
 ## Pre-commit hook
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,8 @@ pnpm smoke:image
 The default command builds `ralph-sandbox:smoke` from
 `packages/core/templates/Dockerfile` with the repository root as its Docker build
 context, then checks the default `agent` user, `python`, `python3`, venv creation,
-pip inside the venv, `uv`, and an `uv` install of the pure-Python `six` package from
-PyPI.
+pip inside the venv, recognizable `uv --version` and `uvx --version` output, and an
+`uv` install of the pure-Python `six` package from PyPI.
 
 To smoke an already-built release candidate without rebuilding it, pass its tag:
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,6 +29,17 @@ docker pull docker.io/daonhan/ralph-sandbox:latest
 
 (Ralph also auto-pulls on first run; this just primes the cache.)
 
+The image already provides Debian Bookworm Python 3.11 as `python` and `python3`,
+`python -m venv`, and `uv`/`uvx` 0.11.28, so basic Python repositories need no
+extra runtime install. Use a project-local virtual environment or uv-managed
+isolation; do not install project dependencies globally into the Debian system
+Python.
+
+This release does not select pinned Python versions from `.python-version`,
+`.tool-versions`, `.mise.toml`, `pyproject.toml`, or similar manifests. A repository
+that requires another Python version needs a custom image until future detection
+support is added.
+
 ## 4. One-off auth
 
 Credentials live on the **host** (`~/.claude`, `~/.config/gh`) and get bind-mounted into every container. Log in once via an interactive container.

--- a/README.md
+++ b/README.md
@@ -155,11 +155,24 @@ cd ralph
 docker build -t docker.io/daonhan/ralph-sandbox:latest -f packages/core/templates/Dockerfile .
 ```
 
-The image bundles: Node 22, .NET SDK 10, `gh`, `jq`, `git`, the Claude Code CLI.
+The image bundles Node 22, Debian Bookworm Python 3.11 as `python` and `python3`,
+`python -m venv`, `uv`/`uvx` 0.11.28, .NET SDK 10, `gh`, `jq`, `git`, and the
+Claude Code CLI. Basic Python repositories need no extra runtime install. Create a
+project-local virtual environment (for example, `.venv`) or use uv-managed
+isolation; do not install project dependencies globally into the Debian system
+Python.
+
+This release provides one baked system Python and does not select versions from
+`.python-version`, `.tool-versions`, `.mise.toml`, `pyproject.toml`, or similar
+manifests. Repositories pinned to another Python version need a custom
+`RALPH_IMAGE` until future version-detection support is added.
 
 #### Publishing a new image (maintainers)
 
 The repo ships a GitHub Actions workflow at [`.github/workflows/publish-image.yml`](./.github/workflows/publish-image.yml) that builds + pushes `linux/amd64` images to Docker Hub.
+
+The Python runtime and tooling addition is a `ralph-sandbox` image release only;
+it does not bump `@daonhan/ralph-core` or `@daonhan/ralph`.
 
 Triggers:
 
@@ -533,7 +546,7 @@ The agent playbooks are self-contained: `packages/core/templates/prompt.md` (pla
 | [`apps/cli/scripts/ghafk.sh`](./apps/cli/scripts/ghafk.sh)                       | Optional shim — GitHub-issue loop. Calls `ralph-ghafk`.                                                                                                                      |
 | [`packages/core/templates/prompt.md`](./packages/core/templates/prompt.md)       | Agent playbook for `ralph-afk`. Shipped in core tarball.                                                                                                                     |
 | [`packages/core/templates/ghprompt.md`](./packages/core/templates/ghprompt.md)   | Agent playbook for `ralph-ghafk`. Shipped in core tarball.                                                                                                                   |
-| [`packages/core/templates/Dockerfile`](./packages/core/templates/Dockerfile)     | Builds `ralph-sandbox` image: Node 22 + .NET SDK 10 + `gh` + `claude`. Shipped in `@daonhan/ralph-core` tarball.                                                             |
+| [`packages/core/templates/Dockerfile`](./packages/core/templates/Dockerfile)     | Builds `ralph-sandbox` image: Node 22 + Python 3.11/venv + `uv`/`uvx` + .NET SDK 10 + `gh` + `claude`. Shipped in `@daonhan/ralph-core` tarball.                             |
 | [`.dockerignore`](./.dockerignore)                                               | Shrinks build context (consumed at repo root for CI builds).                                                                                                                 |
 | [`package.json`](./package.json)                                                 | Monorepo root (private). Shared devDeps + pnpm workspace scripts.                                                                                                            |
 | [`pnpm-workspace.yaml`](./pnpm-workspace.yaml)                                   | Declares `apps/*` and `packages/*` as workspace members.                                                                                                                     |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,6 +71,9 @@ Release PR appears.
      attestation.
 6. Watch the Actions tab; the publish workflow run links to the published artifact.
 
+A Python runtime or tooling change confined to the sandbox image is a
+`ralph-sandbox` release only. It does not bump either npm package.
+
 > **Token requirement.** release-please must create tags with a Personal Access
 > Token (`RELEASE_PLEASE_TOKEN` secret, repo scope), because a tag created with the
 > default `GITHUB_TOKEN` does **not** trigger the `push: tags` publish workflows.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,12 @@ Release PR appears.
    unreleased commits. The PR bumps the version, amends `CHANGELOG.md`, and carries
    the refreshed status table.
 3. Review the PR: confirm the proposed version and the CHANGELOG diff read the way
-   you want users to see them.
+   you want users to see them. Before merging a `ralph-sandbox` Release PR, run
+   `pnpm smoke:image` from the release candidate revision. This full build-and-smoke
+   (including its network package-install check) is required before publishing; an
+   offline `--skip-network` run does not satisfy the release gate. If the candidate
+   image was built separately, verify that exact tag with
+   `pnpm smoke:image -- --image <candidate-tag>`.
 4. **Merge the Release PR.** That single action creates the component tag
    (`<component>-vX.Y.Z`) and the GitHub Release.
 5. The tag triggers the matching publish workflow:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -360,7 +360,7 @@ pnpm test
 
 The pre-commit hook ([`../.husky/pre-commit`](../.husky/pre-commit)) runs `pnpm exec lint-staged` (Prettier `--write` on staged files) then `pnpm typecheck`. The root `prepare` script is `husky || git config core.hooksPath .husky` so installs still work if Husky does not self-initialize.
 
-Build the sandbox image locally from [`../packages/core/templates/Dockerfile`](../packages/core/templates/Dockerfile) (`node:22-bookworm` + git/curl/jq + .NET SDK 10 + `gh` + Claude Code CLI; base `node` user renamed to `agent` UID 1000; `safe.directory=*` global; `WORKDIR /home/agent/workspace`; `ENTRYPOINT []`, `CMD ["claude"]`):
+Build the sandbox image locally from [`../packages/core/templates/Dockerfile`](../packages/core/templates/Dockerfile) (`node:22-bookworm` + Debian Bookworm Python 3.11 exposed as `python`/`python3` + `python -m venv` + pinned `uv`/`uvx` 0.11.28 + git/curl/jq + .NET SDK 10 + `gh` + Claude Code CLI; base `node` user renamed to `agent` UID 1000; `safe.directory=*` global; `WORKDIR /home/agent/workspace`; `ENTRYPOINT []`, `CMD ["claude"]`):
 
 ```bash
 docker build -t docker.io/daonhan/ralph-sandbox:latest \
@@ -371,6 +371,13 @@ docker build -t docker.io/daonhan/ralph-sandbox:latest \
 docker build -t docker.io/daonhan/ralph-sandbox:latest `
   -f packages/core/templates/Dockerfile .
 ```
+
+Python runtime selection is static: the image supplies one baked system Python,
+and the runner does not inspect `.python-version`, `.tool-versions`, `.mise.toml`,
+`pyproject.toml`, or similar manifests. Repositories pinned to another version
+must use a custom image until detection support exists. Project dependencies
+belong in a project-local virtual environment or uv-managed isolation, not in the
+Debian system Python.
 
 Diagnose resolved config (workspace / docker context / image / socket) without launching Docker:
 

--- a/docs/plans/python-sandbox-support.md
+++ b/docs/plans/python-sandbox-support.md
@@ -1,0 +1,112 @@
+# Plan: Python Support for ralph-sandbox
+
+> Source PRD: [`docs/prd/python-sandbox-support.md`](../prd/python-sandbox-support.md)
+
+## Architectural decisions
+
+Durable decisions that apply across all phases. Touch these only with a follow-up PRD.
+
+- **Scope of change**: this is a `ralph-sandbox` image feature. No changes to stage orchestration, template rendering, Docker-run argument construction, CLI parsing, or prompt playbooks.
+- **Runtime contract**: the image exposes Debian Bookworm's system Python as both `python3` and `python`. Python 3 is the only supported Python line.
+- **Environment contract**: `python -m venv` works for project-local virtual environments. Project dependencies belong in a virtual environment or isolated tool-managed location, not in system Python.
+- **Package tooling**: include at least one modern Python package runner/installer that works for the non-root `agent` user in non-interactive Docker runs. `uv` is preferred; `pipx` is the minimum fallback for isolated CLI installs.
+- **Global packages**: do not preinstall project-level tools such as pytest, ruff, mypy, poetry, flask, django, or fastapi. Target repos own those dependencies.
+- **Native build baseline**: common compiler/build basics may be added if the image-size increase is acceptable. Domain-specific headers and heavyweight stacks stay out of scope.
+- **Version selection**: no `.python-version`, `.tool-versions`, `.mise.toml`, `pyproject.toml`, or runtime-detection behavior in this plan. A single baked system Python is the feature.
+- **Release component**: Dockerfile/image-input changes belong to the synthetic `ralph-sandbox` component. npm packages should not bump for this image-only feature.
+- **Verification seam**: the highest useful test seam is a Docker image smoke test that validates the container's external Python contract.
+- **Docs contract**: user-facing docs must name Python as part of the sandbox image and clearly state that pinned Python version selection is future work.
+
+---
+
+## Phase 1: Baseline Python Runtime
+
+**User stories**: 1, 2, 3, 6, 8, 9, 10, 11, 14, 16, 19, 20, 22
+
+### What to build
+
+Make Python a real image contract instead of an accidental base-image detail. The sandbox image should build cleanly, run as the existing `agent` user, expose Python through both command names, and create a working project-local virtual environment with pip available inside it.
+
+This phase proves the smallest useful Python path end-to-end: a Python repo can be mounted into the sandbox, the agent can create a virtual environment, and dependency installation has a proper place to happen.
+
+### Acceptance criteria
+
+- [ ] The sandbox image builds locally from the repo root using the existing Dockerfile path and image-build command shape.
+- [ ] `docker run --rm <image> python --version` exits successfully and reports Python 3.
+- [ ] `docker run --rm <image> python3 --version` exits successfully and reports Python 3.
+- [ ] `docker run --rm <image> python -m venv /tmp/ralph-python-smoke` exits successfully as the `agent` user.
+- [ ] The virtual environment's Python can run `-m pip --version`.
+- [ ] The implementation respects Debian's externally-managed system Python model; project dependency installs are validated inside a virtual environment, not against system Python.
+- [ ] No project-level Python tools are installed globally as part of the baseline runtime.
+- [ ] No core loop, runner, CLI, stage, or prompt behavior changes are introduced.
+- [ ] Existing release-please path-scoping tests still confirm that an image-input change bumps `ralph-sandbox`, not `ralph-core` or `ralph`.
+
+---
+
+## Phase 2: Modern Python Tooling
+
+**User stories**: 4, 5, 12, 13, 14, 15, 16, 24
+
+### What to build
+
+Add the minimal modern Python tooling needed for common Python repos without turning the image into an opinionated Python application stack. Prefer `uv` if it can be installed in a way that is stable for the `agent` user and available in non-interactive `docker run` commands. Keep `pipx` as the isolated-CLI fallback or complement.
+
+This phase proves that the sandbox can handle both classic and current Python workflows: creating an environment, installing a tiny dependency, and invoking the chosen package tool from the same user context the agent uses.
+
+### Acceptance criteria
+
+- [ ] The chosen modern package tool reports a version from a plain non-interactive container run.
+- [ ] The chosen tool is available on `PATH` for the `agent` user without relying on interactive shell startup files.
+- [ ] A virtual environment can install a small pure-Python dependency from PyPI when network access is available.
+- [ ] If `uv` is included, `uv --version` works and at least one `uv`-based environment or install smoke succeeds.
+- [ ] If `pipx` is included, `pipx --version` works and its install location is writable by the `agent` user.
+- [ ] The implementation does not globally install test, lint, framework, data science, ML, browser automation, or database-specific Python packages.
+- [ ] Any native-build prerequisites added to the image are limited to a generic build baseline and their image-size impact is recorded for review.
+- [ ] Existing Node, .NET, `gh`, `jq`, git, Claude Code, workdir, user, and entrypoint behavior continue to work after the Python additions.
+
+---
+
+## Phase 3: Image Smoke Guard
+
+**User stories**: 7, 18, 21
+
+### What to build
+
+Create a repeatable image smoke check that maintainers can run before publishing a sandbox image. The smoke should exercise the image contract from outside the container, fail with clear messages, and avoid coupling to apt package names or Dockerfile layer ordering.
+
+This phase turns Python support from a one-time manual verification into a durable guardrail for future image changes.
+
+### Acceptance criteria
+
+- [ ] A root-level smoke command can build or accept a prebuilt sandbox image tag and run the Python contract checks against it.
+- [ ] The smoke verifies `python`, `python3`, `venv`, pip inside the virtual environment, and the chosen modern package tool.
+- [ ] Network-dependent package-install verification is either clearly marked as requiring network or can be skipped with an explicit flag/env var.
+- [ ] Smoke failures identify the missing or broken contract in plain language.
+- [ ] The smoke command is documented in the maintainer verification flow for image changes.
+- [ ] Ordinary non-image CI remains reasonably fast; if the full Docker build smoke is not added to every PR, the release checklist treats it as required before publishing.
+- [ ] Existing root tests and smoke checks still pass after adding the new image smoke path.
+
+---
+
+## Phase 4: Docs And Release Readiness
+
+**User stories**: 17, 21, 23, 24, 25
+
+### What to build
+
+Update the public and maintainer-facing docs so the image contract matches reality. The docs should make Python discoverable to users, explain the project-local environment expectation, and set clear boundaries around what this first Python release does not do.
+
+This phase also performs the final release-readiness pass: local verification, image smoke, and one toy Python repo run if credentials are available.
+
+### Acceptance criteria
+
+- [ ] The main image bundle description names Python, venv support, and the chosen modern Python package tool.
+- [ ] Quickstart/setup docs do not require extra Python installation for basic Python repos.
+- [ ] Architecture docs describe Python as part of the sandbox image contents.
+- [ ] Docs clearly state that pinned Python version detection is not included in this release.
+- [ ] Docs steer agents/users toward virtual environments or isolated tooling, not global system-Python installs.
+- [ ] The release notes or maintainer checklist identify this as a `ralph-sandbox` image release, not an npm package release.
+- [ ] Full repo verification passes for non-image code paths.
+- [ ] The Python image smoke passes against the final local image tag.
+- [ ] A toy Python repo can complete a basic container-level workflow: create venv, install dependency, run a Python command or test.
+- [ ] If Claude credentials are available, one Ralph iteration against a tiny Python repo succeeds without a custom image.

--- a/docs/prd/python-sandbox-support.md
+++ b/docs/prd/python-sandbox-support.md
@@ -1,0 +1,137 @@
+# PRD: Python Support for ralph-sandbox
+
+## Problem Statement
+
+As a Ralph user, when I point `ralph-afk` or `ralph-ghafk` at a Python repository, the sandbox image does not make Python an explicit supported runtime. The image is currently documented around Node 22, .NET SDK 10, GitHub CLI, common shell utilities, and Claude Code. If Python is present only by accident through the base image or a transitive package, users cannot rely on it for agent work.
+
+That means a Python repo can fail at the first basic task: creating a virtual environment, installing dependencies from `pyproject.toml` or `requirements.txt`, running tests, or invoking standard Python tooling. Worse, a task might pass locally only because the current image happens to contain a Python binary, then break later when the base image changes and that implicit dependency disappears.
+
+Python support is now a concrete need. The earlier multi-version runtime work intentionally left Python out until a concrete need appeared; this PRD scopes the first Python step as a small, reliable image contract rather than a full runtime-detection system.
+
+## Solution
+
+The sandbox image will explicitly support Python as a first-class baked runtime. From the user's perspective, a Python repo should work in the same ordinary way a Node or .NET repo works today:
+
+- `python` and `python3` are available in every container.
+- `python -m venv` works, so agents can create project-local virtual environments.
+- `python -m pip` is available inside virtual environments.
+- A modern Python package runner/installer is available for repos that use current Python workflows.
+- Ralph documentation names Python as part of the image contract.
+- Release and smoke verification catch a future image change that accidentally drops Python support.
+
+This PRD intentionally starts with one system Python from the Debian Bookworm package stream. It does not try to pick Python versions from project manifests yet. The first win is simple: Python repos are no longer relying on an accidental base-image detail.
+
+## User Stories
+
+1. As a Ralph user with a Python repository, I want `python` to exist inside the sandbox, so that the agent can run normal Python commands without first installing a runtime.
+2. As a Ralph user with a Python repository, I want `python3` to exist inside the sandbox, so that scripts and documentation that use the explicit Python 3 command keep working.
+3. As a Ralph user with a Python package, I want `python -m venv` to work, so that the agent can isolate dependencies in a project-local virtual environment.
+4. As a Ralph user with a `requirements.txt` file, I want the agent to be able to install dependencies into a virtual environment, so that it can run my tests.
+5. As a Ralph user with a `pyproject.toml` file, I want the sandbox to support modern Python project workflows, so that agents can install and test the project without special bootstrapping.
+6. As a Ralph user with a repo that documents `python` instead of `python3`, I want the `python` command to map to Python 3, so that existing scripts do not fail on command-name differences.
+7. As a Ralph user, I want Python support to be part of the published image contract, so that I can trust it across image rebuilds.
+8. As a Ralph user, I want Python support to work without a private image fork, so that I can use the default `daonhan/ralph-sandbox` image.
+9. As a Ralph user, I want Python support to work in the same bind-mounted workspace model as the rest of Ralph, so that dependencies and generated files land in my repo when the agent creates them.
+10. As a Ralph user, I want agents to prefer project-local environments over global Python installs, so that one repo's dependencies do not pollute another repo's run.
+11. As a Ralph user, I want the sandbox to include enough Python packaging basics for common repos, so that trivial Python tasks do not spend their first iteration installing infrastructure.
+12. As a Ralph user using `uv`, I want the sandbox to include `uv` or a documented equivalent, so that current fast Python workflows are available out of the box.
+13. As a Ralph user using `pipx`-style isolated CLI installs, I want `pipx` or an equivalent isolated tool path available, so that the agent can install one-off Python CLIs without polluting system packages.
+14. As a Ralph user on Debian-based tooling, I want the image to respect externally-managed-system-Python behavior, so that package installs go into virtual environments or tool-managed locations rather than breaking system Python.
+15. As a Ralph user with native Python dependencies, I want the implementation to consider build prerequisites, so that packages with C extensions can compile when prebuilt wheels are unavailable.
+16. As a Ralph user on a slow connection, I want the Python addition to avoid unnecessary heavyweight global packages, so that the sandbox image does not grow more than needed.
+17. As a Ralph user, I want the image docs to tell me what Python support means, so that I know whether I need a custom image for a pinned Python version.
+18. As a Ralph maintainer, I want a cheap smoke test for Python image support, so that a future Dockerfile edit cannot accidentally remove it.
+19. As a Ralph maintainer, I want Python support isolated to the sandbox image component, so that adding Python does not force an npm package release.
+20. As a Ralph maintainer, I want release-please to route the change to the synthetic image component, so that the Docker image version is the only artifact that bumps.
+21. As a Ralph maintainer, I want CI or a manual release checklist to verify `python`, `venv`, and package installation behavior, so that the published image is trustworthy before `:latest` moves.
+22. As a Ralph maintainer, I want the first Python release to stay smaller than the earlier multi-version-runtime plan, so that the project gets immediate value without taking on runtime detection and cache-volume complexity.
+23. As a Ralph maintainer, I want Python version detection called out as future work, so that this PRD does not accidentally promise `.python-version` or `.tool-versions` behavior.
+24. As a Ralph maintainer, I want framework-specific Python tooling left to target repos, so that the image does not preinstall every possible test, lint, or web framework.
+25. As a Ralph maintainer, I want the docs to match the image contents, so that README, Quickstart, and architecture references do not drift.
+
+## Implementation Decisions
+
+### Scope
+
+- Treat this as a `ralph-sandbox` image feature, not a core loop feature. No changes are needed to stage orchestration, template rendering, Docker-run argument construction, or CLI parsing.
+- Keep the first version intentionally static: one baked Python runtime from the Debian Bookworm package stream. Version selection and manifest detection are future work.
+- Preserve the existing base-image strategy and add Python packages to the existing system-dependency installation flow.
+- Keep the existing non-root `agent` runtime user model. Python tooling must work for that user in the bind-mounted workspace.
+
+### Baked Python Contract
+
+- The image provides both `python3` and `python`, with `python` resolving to Python 3.
+- The image provides `venv` support so project-local virtual environments can be created without additional apt packages.
+- The image provides pip behavior suitable for virtual environments. Agents should install project dependencies into a virtual environment or an isolated tool-managed location rather than into system Python.
+- The image includes a modern fast Python package tool. `uv` is the preferred default if its install path is reliable under the `agent` user; otherwise `pipx` is the fallback minimum for isolated CLI installation.
+- Avoid preinstalling project-level tools like pytest, ruff, mypy, poetry, flask, django, or fastapi. Those belong to the target repo's dependency declaration.
+
+### Native Build Support
+
+- Include common build prerequisites only if they are needed for a useful baseline. The default recommendation is to include compiler/build basics if the image size increase is acceptable, because many Python packages still compile native extensions on less-common platforms or versions.
+- Do not add database-client development headers, browser automation dependencies, ML stacks, or scientific libraries in this PRD. Those are too domain-specific for the base sandbox image.
+
+### Documentation Contract
+
+- The user-facing image bundle list should name Python explicitly.
+- The architecture docs should describe Python as part of the sandbox image contents.
+- The quickstart path should not require extra Python setup for basic Python repos.
+- Documentation should state that only the baked system Python is supported in this PRD, and that project-specific Python version selection requires a custom image or future runtime detection work.
+
+### Release Contract
+
+- The change belongs to the synthetic Docker image component because it changes image inputs under the templates-owned area.
+- Release-please should produce a `ralph-sandbox` release only. The npm packages should not be bumped for this minimal image-only change.
+- The published image should continue to use the existing image workflow and tagging scheme.
+
+## Testing Decisions
+
+Good tests for this feature verify the image's external contract: commands that a Python repo expects should work inside a container built from the sandbox Dockerfile. Tests should not assert apt package internals or installation-layer ordering.
+
+The highest useful seam is a Docker image smoke test. It should build the sandbox image from the Dockerfile, run a disposable container, and verify:
+
+- `python --version` exits successfully and reports Python 3.
+- `python3 --version` exits successfully.
+- `python -m venv /tmp/venv` creates a virtual environment.
+- The virtual environment's Python can run `-m pip --version`.
+- A tiny dependency can be installed into the virtual environment from PyPI, if network-enabled smoke tests are acceptable.
+- The chosen modern package tool reports a version.
+
+For fast local and CI feedback, the smoke can be implemented as a small root-level script following the existing smoke-script style: command-line oriented, clear failure messages, no coupling to implementation details. The script can be optional in ordinary CI if Docker build time is too expensive, but it should be part of the release checklist before publishing the image.
+
+Prior art in the repo:
+
+- Existing root smoke scripts validate rendered templates and spill behavior from the outside.
+- The image integration script already exercises the real Docker CLI for image-resolution behavior.
+- The release-please config test already protects the synthetic image component's path routing.
+
+Manual verification before release:
+
+1. Build the sandbox image locally.
+2. Run `python --version` and `python3 --version` in the image.
+3. Create a virtual environment under `/tmp`.
+4. Install one trivial package inside that virtual environment.
+5. Verify the modern package tool is callable as the `agent` user.
+6. Run a toy Python repo through one Ralph iteration if Claude credentials are available.
+
+## Out of Scope
+
+- Python version detection from `.python-version`, `.tool-versions`, `.mise.toml`, `runtime.txt`, `pyproject.toml`, or similar manifests.
+- Lazy installation of alternate Python versions.
+- Docker named-volume caching for Python runtimes.
+- Reworking the broader multi-version runtime plan.
+- Installing project-specific Python tooling globally.
+- Installing heavy Python stacks such as data science, ML, browser automation, or database-client packages.
+- Supporting Python 2.
+- Guaranteeing exact patch-level Python versions across all future Debian Bookworm package updates.
+- Changing the Ralph prompt templates to give Python-specific instructions.
+- Changing stage orchestration or Docker-run environment plumbing.
+- Publishing a separate Python-specific image variant.
+
+## Further Notes
+
+- Debian Bookworm's system Python is externally managed, so global `pip install` against system Python is the wrong contract. The image should make virtual environments and isolated tool installs easy instead.
+- `uv` gives the best user experience for modern Python repos, but the implementer should verify its install method is stable for a non-root `agent` user and does not depend on shell startup files that Docker's `CMD` path skips.
+- `pipx` is useful as a fallback or complement for isolated Python CLI installs, but it should not replace project-local virtual environments for repo dependencies.
+- If image size becomes a concern, build prerequisites can be revisited. The minimum viable support is the Python runtime, `venv`, packaging basics, and documentation.
+- This PRD is deliberately narrower than the existing multi-version runtime PRD. A future Python runtime-detection PRD can extend the existing detection vocabulary with `.python-version`, `.tool-versions`, and `.mise.toml` once users need pinned versions.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "pnpm -r run build",
     "clean": "pnpm -r run clean",
     "typecheck": "pnpm -r run typecheck",
-    "test": "node --test scripts/runner-floating-ref.test.mjs scripts/release-please-config.test.mjs scripts/update-status-table.test.mjs scripts/registries-not-behind-git.test.mjs",
+    "test": "node --test scripts/runner-floating-ref.test.mjs scripts/release-please-config.test.mjs scripts/update-status-table.test.mjs scripts/registries-not-behind-git.test.mjs scripts/smoke-image.test.mjs",
+    "smoke:image": "node scripts/smoke-image.mjs",
     "publish-all": "pnpm -r publish --access public --no-git-checks",
     "prepare": "husky || git config core.hooksPath .husky"
   },

--- a/packages/core/templates/Dockerfile
+++ b/packages/core/templates/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:22-bookworm
 
+COPY --from=ghcr.io/astral-sh/uv:0.11.28 /uv /uvx /bin/
+
 # System dependencies
 RUN apt-get update && apt-get install -y \
     git \

--- a/packages/core/templates/Dockerfile
+++ b/packages/core/templates/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && apt-get install -y \
     wget \
     ca-certificates \
     gnupg \
+    python3 \
+    python3-venv \
+    python-is-python3 \
   && rm -rf /var/lib/apt/lists/*
 
 # .NET SDK 10 (Microsoft package feed for Debian 12 / Bookworm)

--- a/scripts/smoke-image.mjs
+++ b/scripts/smoke-image.mjs
@@ -4,19 +4,19 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 export function parseSmokeArgs(args, env = process.env) {
-  const imageIndex = args.indexOf("--image");
+  let imageArg = null;
   for (let index = 0; index < args.length; index++) {
     if (args[index] === "--image") {
       const image = args[index + 1];
       if (!image || image.trim() === "" || image.startsWith("--")) {
         throw new Error("--image requires an image tag");
       }
+      imageArg = image.trim();
       index++;
     } else if (args[index] !== "--skip-network") {
       throw new Error(`unknown argument: ${args[index]}`);
     }
   }
-  const imageArg = imageIndex === -1 ? null : args[imageIndex + 1].trim();
   const envImage = env.RALPH_SMOKE_IMAGE?.trim() || null;
   const prebuiltImage = imageArg ?? envImage;
   return {
@@ -159,10 +159,16 @@ function main() {
   const options = parseSmokeArgs(process.argv.slice(2));
   runImageSmoke(options, {
     run(command, args) {
-      return spawnSync(command, args, {
+      const isBuild = args[0] === "build";
+      const result = spawnSync(command, args, {
         encoding: "utf8",
-        stdio: args[0] === "build" ? "inherit" : undefined,
+        stdio: isBuild ? "pipe" : undefined,
       });
+      if (isBuild) {
+        if (result.stdout) process.stdout.write(result.stdout);
+        if (result.stderr) process.stderr.write(result.stderr);
+      }
+      return result;
     },
     log(message) {
       console.log(message);

--- a/scripts/smoke-image.mjs
+++ b/scripts/smoke-image.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export function parseSmokeArgs(args, env = process.env) {
+  const imageIndex = args.indexOf("--image");
+  if (
+    imageIndex !== -1 &&
+    (!args[imageIndex + 1] || args[imageIndex + 1].startsWith("--"))
+  ) {
+    throw new Error("--image requires an image tag");
+  }
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === "--image") {
+      index++;
+    } else if (args[index] !== "--skip-network") {
+      throw new Error(`unknown argument: ${args[index]}`);
+    }
+  }
+  const prebuiltImage =
+    (imageIndex === -1 ? null : args[imageIndex + 1]) ??
+    env.RALPH_SMOKE_IMAGE ??
+    null;
+  return {
+    image: prebuiltImage ?? "ralph-sandbox:smoke",
+    build: prebuiltImage === null,
+    skipNetwork:
+      args.includes("--skip-network") || env.RALPH_SMOKE_SKIP_NETWORK === "1",
+  };
+}
+
+function failureDetail(result) {
+  return (
+    result.error?.message ||
+    String(result.stderr ?? "").trim() ||
+    `docker exited ${result.status}`
+  );
+}
+
+export function runImageSmoke(options, { run, log }) {
+  if (options.build) {
+    log(`Building ${options.image} from packages/core/templates/Dockerfile...`);
+    const result = run("docker", [
+      "build",
+      "--tag",
+      options.image,
+      "--file",
+      "packages/core/templates/Dockerfile",
+      ".",
+    ]);
+    if (result.status !== 0) {
+      throw new Error(`sandbox image build failed: ${failureDetail(result)}`);
+    }
+  }
+
+  const venvSetup =
+    'tmp=$(mktemp -d); trap \'rm -rf "$tmp"\' 0; python -m venv "$tmp"';
+  const checks = [
+    {
+      label: "default container user is agent",
+      entrypoint: "id",
+      args: ["-un"],
+      validateOutput(output) {
+        return output.trim() === "agent"
+          ? null
+          : `got ${output.trim() || "(empty)"}`;
+      },
+    },
+    {
+      label: "python resolves to Python 3",
+      entrypoint: "python",
+      args: ["--version"],
+      validateOutput(output) {
+        return /^Python 3\./.test(output.trim())
+          ? null
+          : `got ${output.trim() || "(empty)"}`;
+      },
+    },
+    {
+      label: "python3 is available",
+      entrypoint: "python3",
+      args: ["--version"],
+      validateOutput(output) {
+        return /^Python 3\./.test(output.trim())
+          ? null
+          : `got ${output.trim() || "(empty)"}`;
+      },
+    },
+    {
+      label: "python -m venv creates a virtual environment",
+      entrypoint: "sh",
+      args: ["-c", `${venvSetup}; test -x \"$tmp/bin/python\"`],
+    },
+    {
+      label: "pip is available inside a virtual environment",
+      entrypoint: "sh",
+      args: ["-c", `${venvSetup}; \"$tmp/bin/python\" -m pip --version`],
+    },
+    {
+      label: "uv is available",
+      entrypoint: "uv",
+      args: ["--version"],
+    },
+  ];
+  if (!options.skipNetwork) {
+    checks.push({
+      label: "uv installs a pure-Python package from PyPI (network)",
+      entrypoint: "sh",
+      network: true,
+      args: [
+        "-c",
+        `${venvSetup}; uv pip install --python \"$tmp/bin/python\" six==1.17.0; \"$tmp/bin/python\" -c 'import six; assert six.__version__ == \"1.17.0\"'`,
+      ],
+    });
+  }
+
+  for (const check of checks) {
+    if (check.network) {
+      log("RUN network package-install check (requires PyPI network access)");
+    }
+    const result = run("docker", [
+      "run",
+      "--rm",
+      "--entrypoint",
+      check.entrypoint,
+      options.image,
+      ...check.args,
+    ]);
+    if (result.status !== 0) {
+      throw new Error(
+        `image contract failed: ${check.label}: ${failureDetail(result)}`
+      );
+    }
+    const outputError = check.validateOutput?.(result.stdout);
+    if (outputError) {
+      throw new Error(`image contract failed: ${check.label}: ${outputError}`);
+    }
+    log(`ok  ${check.label}`);
+  }
+  if (options.skipNetwork) {
+    log("SKIP network package-install check (--skip-network)");
+  }
+}
+
+function main() {
+  const options = parseSmokeArgs(process.argv.slice(2));
+  runImageSmoke(options, {
+    run(command, args) {
+      return spawnSync(command, args, {
+        encoding: "utf8",
+        stdio: args[0] === "build" ? "inherit" : undefined,
+      });
+    },
+    log(message) {
+      console.log(message);
+    },
+  });
+  console.log(`All Python image contracts passed for ${options.image}.`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`image smoke failed: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/smoke-image.mjs
+++ b/scripts/smoke-image.mjs
@@ -5,23 +5,20 @@ import { fileURLToPath } from "node:url";
 
 export function parseSmokeArgs(args, env = process.env) {
   const imageIndex = args.indexOf("--image");
-  if (
-    imageIndex !== -1 &&
-    (!args[imageIndex + 1] || args[imageIndex + 1].startsWith("--"))
-  ) {
-    throw new Error("--image requires an image tag");
-  }
   for (let index = 0; index < args.length; index++) {
     if (args[index] === "--image") {
+      const image = args[index + 1];
+      if (!image || image.trim() === "" || image.startsWith("--")) {
+        throw new Error("--image requires an image tag");
+      }
       index++;
     } else if (args[index] !== "--skip-network") {
       throw new Error(`unknown argument: ${args[index]}`);
     }
   }
-  const prebuiltImage =
-    (imageIndex === -1 ? null : args[imageIndex + 1]) ??
-    env.RALPH_SMOKE_IMAGE ??
-    null;
+  const imageArg = imageIndex === -1 ? null : args[imageIndex + 1].trim();
+  const envImage = env.RALPH_SMOKE_IMAGE?.trim() || null;
+  const prebuiltImage = imageArg ?? envImage;
   return {
     image: prebuiltImage ?? "ralph-sandbox:smoke",
     build: prebuiltImage === null,
@@ -101,6 +98,21 @@ export function runImageSmoke(options, { run, log }) {
       label: "uv is available",
       entrypoint: "uv",
       args: ["--version"],
+      validateOutput(output) {
+        return /^uv \d+\.\d+\.\d+(?:\S*)?(?:\s|$)/.test(output.trim())
+          ? null
+          : `got ${output.trim() || "(empty)"}`;
+      },
+    },
+    {
+      label: "uvx is available",
+      entrypoint: "uvx",
+      args: ["--version"],
+      validateOutput(output) {
+        return /^uvx \d+\.\d+\.\d+(?:\S*)?(?:\s|$)/.test(output.trim())
+          ? null
+          : `got ${output.trim() || "(empty)"}`;
+      },
     },
   ];
   if (!options.skipNetwork) {

--- a/scripts/smoke-image.test.mjs
+++ b/scripts/smoke-image.test.mjs
@@ -17,7 +17,11 @@ function successfulResult(args) {
         ? "agent\n"
         : entrypoint === "python" || entrypoint === "python3"
           ? "Python 3.11.2\n"
-          : "",
+          : entrypoint === "uv"
+            ? "uv 0.11.28 (x86_64-unknown-linux-musl)\n"
+            : entrypoint === "uvx"
+              ? "uvx 0.11.28 (x86_64-unknown-linux-musl)\n"
+              : "",
     stderr: "",
   };
 }
@@ -53,6 +57,17 @@ test("accepts a prebuilt image without scheduling a build", () => {
   });
 });
 
+test("trims an explicit image tag", () => {
+  assert.deepEqual(
+    parseSmokeArgs(["--image", "  example/sandbox:test  "], {}),
+    {
+      image: "example/sandbox:test",
+      build: false,
+      skipNetwork: false,
+    }
+  );
+});
+
 test("accepts a prebuilt image from RALPH_SMOKE_IMAGE", () => {
   assert.deepEqual(
     parseSmokeArgs([], { RALPH_SMOKE_IMAGE: "env-image:test" }),
@@ -62,6 +77,25 @@ test("accepts a prebuilt image from RALPH_SMOKE_IMAGE", () => {
       skipNetwork: false,
     }
   );
+});
+
+test("trims a prebuilt image from RALPH_SMOKE_IMAGE", () => {
+  assert.deepEqual(
+    parseSmokeArgs([], { RALPH_SMOKE_IMAGE: "  env-image:test  " }),
+    {
+      image: "env-image:test",
+      build: false,
+      skipNetwork: false,
+    }
+  );
+});
+
+test("treats whitespace-only RALPH_SMOKE_IMAGE as unset", () => {
+  assert.deepEqual(parseSmokeArgs([], { RALPH_SMOKE_IMAGE: "   " }), {
+    image: "ralph-sandbox:smoke",
+    build: true,
+    skipNetwork: false,
+  });
 });
 
 test("accepts explicit flag and env forms for skipping the network check", () => {
@@ -82,6 +116,20 @@ test("rejects --image without a tag", () => {
 test("rejects --image when the next token is another flag", () => {
   assert.throws(
     () => parseSmokeArgs(["--image", "--skip-network"], {}),
+    /--image requires an image tag/
+  );
+});
+
+test("rejects --image with a whitespace-only tag", () => {
+  assert.throws(
+    () => parseSmokeArgs(["--image", "   "], {}),
+    /--image requires an image tag/
+  );
+});
+
+test("rejects a repeated --image with a whitespace-only tag", () => {
+  assert.throws(
+    () => parseSmokeArgs(["--image", "sandbox:first", "--image", "   "], {}),
     /--image requires an image tag/
   );
 });
@@ -136,15 +184,19 @@ test("prebuilt mode runs every Python image contract from outside the container"
       ["run", "--rm", "--entrypoint", "python3", "sandbox:test", "--version"],
     ],
   ]);
-  assert.equal(calls.length, 7);
+  assert.equal(calls.length, 8);
   assert.match(calls[3][1].at(-1), /python -m venv/);
   assert.match(calls[4][1].at(-1), /bin\/python" -m pip --version/);
   assert.deepEqual(calls[5], [
     "docker",
     ["run", "--rm", "--entrypoint", "uv", "sandbox:test", "--version"],
   ]);
-  assert.match(calls[6][1].at(-1), /uv pip install/);
-  assert.match(calls[6][1].at(-1), /six==1\.17\.0/);
+  assert.deepEqual(calls[6], [
+    "docker",
+    ["run", "--rm", "--entrypoint", "uvx", "sandbox:test", "--version"],
+  ]);
+  assert.match(calls[7][1].at(-1), /uv pip install/);
+  assert.match(calls[7][1].at(-1), /six==1\.17\.0/);
 });
 
 test("each failed check names the broken image contract", () => {
@@ -155,6 +207,7 @@ test("each failed check names the broken image contract", () => {
     "python -m venv creates a virtual environment",
     "pip is available inside a virtual environment",
     "uv is available",
+    "uvx is available",
     "uv installs a pure-Python package from PyPI (network)",
   ];
 
@@ -211,10 +264,73 @@ test("rejects a python3 command that is not Python 3", () => {
   );
 });
 
+test("rejects empty uv version output", () => {
+  assert.throws(
+    () =>
+      executeSmoke(PREBUILT_ARGS, (args) => ({
+        ...successfulResult(args),
+        stdout:
+          args[args.indexOf("--entrypoint") + 1] === "uv"
+            ? ""
+            : successfulResult(args).stdout,
+      })),
+    /uv is available.*got \(empty\)/
+  );
+});
+
+test("rejects malformed uv version output", () => {
+  assert.throws(
+    () =>
+      executeSmoke(PREBUILT_ARGS, (args) => ({
+        ...successfulResult(args),
+        stdout:
+          args[args.indexOf("--entrypoint") + 1] === "uv"
+            ? "uv version unknown\n"
+            : successfulResult(args).stdout,
+      })),
+    /uv is available.*got uv version unknown/
+  );
+});
+
+test("accepts recognizable uv and uvx version output", () => {
+  assert.doesNotThrow(() => executeSmoke(PREBUILT_ARGS));
+});
+
+test("rejects an image without uvx", () => {
+  assert.throws(
+    () =>
+      executeSmoke(PREBUILT_ARGS, (args) => {
+        const entrypoint = args[args.indexOf("--entrypoint") + 1];
+        return entrypoint === "uvx"
+          ? { status: 127, stdout: "", stderr: "uvx: not found" }
+          : successfulResult(args);
+      }),
+    /uvx is available.*uvx: not found/
+  );
+});
+
+test("rejects malformed uvx version output", () => {
+  assert.throws(
+    () =>
+      executeSmoke(PREBUILT_ARGS, (args) => ({
+        ...successfulResult(args),
+        stdout:
+          args[args.indexOf("--entrypoint") + 1] === "uvx"
+            ? "uvx version unknown\n"
+            : successfulResult(args).stdout,
+      })),
+    /uvx is available.*got uvx version unknown/
+  );
+});
+
 test("reports when the network package-install check is skipped", () => {
   const { calls, logs } = executeSmoke([...PREBUILT_ARGS, "--skip-network"]);
 
-  assert.equal(calls.length, 6);
+  assert.equal(calls.length, 7);
+  assert.deepEqual(calls.at(-1), [
+    "docker",
+    ["run", "--rm", "--entrypoint", "uvx", "sandbox:test", "--version"],
+  ]);
   assert.match(logs.at(-1), /SKIP.*network package-install check/);
 });
 

--- a/scripts/smoke-image.test.mjs
+++ b/scripts/smoke-image.test.mjs
@@ -134,6 +134,20 @@ test("rejects a repeated --image with a whitespace-only tag", () => {
   );
 });
 
+test("uses the last repeated --image tag", () => {
+  assert.deepEqual(
+    parseSmokeArgs(
+      ["--image", "sandbox:first", "--image", "sandbox:second"],
+      {}
+    ),
+    {
+      image: "sandbox:second",
+      build: false,
+      skipNetwork: false,
+    }
+  );
+});
+
 test("rejects unknown arguments", () => {
   assert.throws(
     () => parseSmokeArgs(["--surprise"], {}),

--- a/scripts/smoke-image.test.mjs
+++ b/scripts/smoke-image.test.mjs
@@ -1,0 +1,282 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseSmokeArgs, runImageSmoke } from "./smoke-image.mjs";
+
+const SCRIPT = fileURLToPath(new URL("./smoke-image.mjs", import.meta.url));
+const PREBUILT_ARGS = ["--image", "sandbox:test"];
+
+function successfulResult(args) {
+  const entrypoint = args[args.indexOf("--entrypoint") + 1];
+  return {
+    status: 0,
+    stdout:
+      entrypoint === "id"
+        ? "agent\n"
+        : entrypoint === "python" || entrypoint === "python3"
+          ? "Python 3.11.2\n"
+          : "",
+    stderr: "",
+  };
+}
+
+function executeSmoke(args, resultFor = successfulResult) {
+  const calls = [];
+  const logs = [];
+  runImageSmoke(parseSmokeArgs(args, {}), {
+    run(command, commandArgs) {
+      calls.push([command, commandArgs]);
+      return resultFor(commandArgs, calls.length - 1);
+    },
+    log(message) {
+      logs.push(message);
+    },
+  });
+  return { calls, logs };
+}
+
+test("uses the documented Dockerfile and root context by default", () => {
+  assert.deepEqual(parseSmokeArgs([], {}), {
+    image: "ralph-sandbox:smoke",
+    build: true,
+    skipNetwork: false,
+  });
+});
+
+test("accepts a prebuilt image without scheduling a build", () => {
+  assert.deepEqual(parseSmokeArgs(["--image", "example/sandbox:test"], {}), {
+    image: "example/sandbox:test",
+    build: false,
+    skipNetwork: false,
+  });
+});
+
+test("accepts a prebuilt image from RALPH_SMOKE_IMAGE", () => {
+  assert.deepEqual(
+    parseSmokeArgs([], { RALPH_SMOKE_IMAGE: "env-image:test" }),
+    {
+      image: "env-image:test",
+      build: false,
+      skipNetwork: false,
+    }
+  );
+});
+
+test("accepts explicit flag and env forms for skipping the network check", () => {
+  assert.equal(parseSmokeArgs(["--skip-network"], {}).skipNetwork, true);
+  assert.equal(
+    parseSmokeArgs([], { RALPH_SMOKE_SKIP_NETWORK: "1" }).skipNetwork,
+    true
+  );
+});
+
+test("rejects --image without a tag", () => {
+  assert.throws(
+    () => parseSmokeArgs(["--image"], {}),
+    /--image requires an image tag/
+  );
+});
+
+test("rejects --image when the next token is another flag", () => {
+  assert.throws(
+    () => parseSmokeArgs(["--image", "--skip-network"], {}),
+    /--image requires an image tag/
+  );
+});
+
+test("rejects unknown arguments", () => {
+  assert.throws(
+    () => parseSmokeArgs(["--surprise"], {}),
+    /unknown argument: --surprise/
+  );
+});
+
+test("build mode uses the documented Dockerfile and root context", () => {
+  const { calls } = executeSmoke([]);
+
+  assert.deepEqual(calls[0], [
+    "docker",
+    [
+      "build",
+      "--tag",
+      "ralph-sandbox:smoke",
+      "--file",
+      "packages/core/templates/Dockerfile",
+      ".",
+    ],
+  ]);
+});
+
+test("reports a failed image build in plain language", () => {
+  assert.throws(
+    () =>
+      runImageSmoke(parseSmokeArgs([], {}), {
+        run() {
+          return { status: 17, stdout: "", stderr: "build exploded" };
+        },
+        log() {},
+      }),
+    /sandbox image build failed.*build exploded/
+  );
+});
+
+test("prebuilt mode runs every Python image contract from outside the container", () => {
+  const { calls } = executeSmoke(PREBUILT_ARGS);
+
+  assert.deepEqual(calls.slice(0, 3), [
+    ["docker", ["run", "--rm", "--entrypoint", "id", "sandbox:test", "-un"]],
+    [
+      "docker",
+      ["run", "--rm", "--entrypoint", "python", "sandbox:test", "--version"],
+    ],
+    [
+      "docker",
+      ["run", "--rm", "--entrypoint", "python3", "sandbox:test", "--version"],
+    ],
+  ]);
+  assert.equal(calls.length, 7);
+  assert.match(calls[3][1].at(-1), /python -m venv/);
+  assert.match(calls[4][1].at(-1), /bin\/python" -m pip --version/);
+  assert.deepEqual(calls[5], [
+    "docker",
+    ["run", "--rm", "--entrypoint", "uv", "sandbox:test", "--version"],
+  ]);
+  assert.match(calls[6][1].at(-1), /uv pip install/);
+  assert.match(calls[6][1].at(-1), /six==1\.17\.0/);
+});
+
+test("each failed check names the broken image contract", () => {
+  const labels = [
+    "default container user is agent",
+    "python resolves to Python 3",
+    "python3 is available",
+    "python -m venv creates a virtual environment",
+    "pip is available inside a virtual environment",
+    "uv is available",
+    "uv installs a pure-Python package from PyPI (network)",
+  ];
+
+  for (const [failedIndex, label] of labels.entries()) {
+    assert.throws(
+      () =>
+        executeSmoke(PREBUILT_ARGS, (args, callIndex) => ({
+          ...successfulResult(args),
+          status: callIndex === failedIndex ? 1 : 0,
+          stderr: callIndex === failedIndex ? "command exploded" : "",
+        })),
+      new RegExp(`image contract failed: ${label.replace(/[().]/g, "\\$&")}`)
+    );
+  }
+});
+
+test("rejects an image whose default user is not agent", () => {
+  assert.throws(
+    () =>
+      executeSmoke(PREBUILT_ARGS, () => ({
+        status: 0,
+        stdout: "root\n",
+        stderr: "",
+      })),
+    /default container user is agent.*got root/
+  );
+});
+
+test("rejects a python command that is not Python 3", () => {
+  assert.throws(
+    () =>
+      executeSmoke(PREBUILT_ARGS, (args) => ({
+        ...successfulResult(args),
+        stdout:
+          args[args.indexOf("--entrypoint") + 1] === "python"
+            ? "Python 2.7.18\n"
+            : successfulResult(args).stdout,
+      })),
+    /python resolves to Python 3.*got Python 2\.7\.18/
+  );
+});
+
+test("rejects a python3 command that is not Python 3", () => {
+  assert.throws(
+    () =>
+      executeSmoke(PREBUILT_ARGS, (args) => ({
+        ...successfulResult(args),
+        stdout:
+          args[args.indexOf("--entrypoint") + 1] === "python3"
+            ? "unexpected runtime\n"
+            : successfulResult(args).stdout,
+      })),
+    /python3 is available.*got unexpected runtime/
+  );
+});
+
+test("reports when the network package-install check is skipped", () => {
+  const { calls, logs } = executeSmoke([...PREBUILT_ARGS, "--skip-network"]);
+
+  assert.equal(calls.length, 6);
+  assert.match(logs.at(-1), /SKIP.*network package-install check/);
+});
+
+test("reports when the network package-install check runs", () => {
+  const { logs } = executeSmoke(PREBUILT_ARGS);
+
+  assert.ok(
+    logs.some((message) => /RUN.*network package-install check/.test(message))
+  );
+});
+
+test("does not report the network check as run when an earlier contract fails", () => {
+  const logs = [];
+  assert.throws(() => {
+    runImageSmoke(parseSmokeArgs(PREBUILT_ARGS, {}), {
+      run: () => ({ status: 1, stdout: "", stderr: "broken user" }),
+      log: (message) => logs.push(message),
+    });
+  });
+
+  assert.equal(
+    logs.some((message) => /RUN.*network package-install check/.test(message)),
+    false
+  );
+});
+
+test("reports when Docker cannot be started", () => {
+  assert.throws(
+    () =>
+      runImageSmoke(parseSmokeArgs([], {}), {
+        run() {
+          return {
+            status: null,
+            stdout: null,
+            stderr: null,
+            error: new Error("spawnSync docker ENOENT"),
+          };
+        },
+        log() {},
+      }),
+    /sandbox image build failed.*spawnSync docker ENOENT/
+  );
+});
+
+test("the real CLI reports invalid usage and returns non-zero", () => {
+  const result = spawnSync(process.execPath, [SCRIPT, "--surprise"], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /image smoke failed: unknown argument: --surprise/
+  );
+});
+
+test("the root package exposes the image smoke command", () => {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8")
+  );
+  assert.equal(
+    packageJson.scripts["smoke:image"],
+    "node scripts/smoke-image.mjs"
+  );
+});


### PR DESCRIPTION
Complete the Python sandbox support work by tightening the smoke contract around the sandbox image and its documentation.

Changes include:
- added and hardened the Python sandbox smoke-image script and tests
- updated the sandbox Dockerfile and repository docs for the Python runtime contract
- refreshed the supporting plan/PRD and release-facing docs

This keeps the Python runtime expectations executable so regressions are caught earlier.