### PR TITLE
Fix tsconfig by explicitly pinning Node type resolution

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "types": ["node"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,


### PR DESCRIPTION
This PR fixes type resolution drift by explicitly pinning Node ambient types in the TypeScript config.

## What changed
- Updated tsconfig typing configuration to use an explicit Node types array

## Why
- Prevents implicit or environment-dependent Node type pickup
- Keeps workspace typechecking behavior deterministic across environments

Related commit: `41e2fe1`