### PR TITLE
Enable release-please node-workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "include-v-in-tag": true,
   "tag-separator": "-",
   "separate-pull-requests": true,
+  "plugins": [{ "type": "node-workspace", "merge": false }],
   "changelog-path": "CHANGELOG.md",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },


### PR DESCRIPTION
This PR enables the node-workspace plugin in release configuration.

Why: the plugin improves release handling for workspace packages in this monorepo and keeps versioning/release automation aligned across components.

Main change:
- Update release configuration to enable the node-workspace plugin