### PR TITLE
Fix Codex HOME handling for Windows credential mounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,12 +102,12 @@ Every run writes to `<workspaceDir>/.ralph-tmp/` on the host (gitignored): the r
 `runStage` reads `process.env.HOME || USERPROFILE` and mounts only the selected provider's credentials when present:
 
 - Claude: `~/.claude` → `/home/agent/.claude` and `~/.claude.json` → `/home/agent/.claude.json`
-- Codex: `~/.codex` → `/home/agent/.codex`, with `CODEX_HOME=/home/agent/.codex`
+- Codex: `~/.codex` → `/mnt/codex-creds:ro`, with `CODEX_HOME=/home/agent/.codex`; a setup script copies `auth.json`/`config.toml`/`AGENTS.md` into the container-local `CODEX_HOME` before exec'ing `codex` (a bind-mounted `CODEX_HOME` fails with EPERM on Windows)
 - Shared when present: `~/.config/gh` → `/home/agent/.config/gh:ro`
 
 `runStage` also injects git env vars (`GIT_CONFIG_COUNT/KEY_0=safe.directory/VALUE_0=*`) so git trusts the bind-mounted workspace, and — **by default** — bind-mounts the host Docker socket (`-v <sock>:/var/run/docker.sock` + a `--group-add` fixup, via `resolveDockerSocketMount`) so Testcontainers inside the sandbox can spawn sibling containers. That grants the sandbox root-equivalent host Docker access; disable with `RALPH_DOCKER_SOCK=0`, or set an explicit path with `RALPH_DOCKER_SOCK_PATH`.
 
-**Same-shell rule:** these paths resolve against the shell that invoked the bin. PowerShell `$HOME` (`C:\Users\<you>`) and WSL `$HOME` (`/home/<you>`) are separate stores — install/login to the selected host CLI and run Ralph from the same environment. Claude supports native Windows or WSL. Codex on Windows is supported only through WSL: install Ralph and Codex, use file-backed Codex credentials, and run both from the same WSL distro. Keep `gh auth login` in that environment too (see README "Windows + WSL: credentials").
+**Same-shell rule:** these paths resolve against the shell that invoked the bin. PowerShell `$HOME` (`C:\Users\<you>`) and WSL `$HOME` (`/home/<you>`) are separate stores — install/login to the selected host CLI and run Ralph from the same environment. Both providers support native Windows and WSL; Codex needs file-backed credentials (`cli_auth_credentials_store = "file"`). Keep `gh auth login` in that environment too (see README "Windows + WSL: credentials").
 
 ### Sandbox image
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -9,9 +9,8 @@ Ralph drives Claude Code by default, or Codex when selected with `--agent codex`
 ## 1. Prerequisites
 
 - **Docker** running — Docker Desktop (Windows/macOS) or Docker Engine (Linux).
-- **Node.js 20+** with `npm`. Windows Codex users need Node inside WSL; native Windows Node remains supported for Claude.
-- **(Windows Claude, recommended)** `bash.exe` on your `PATH` — comes free with [Git for Windows](https://git-scm.com/download/win). The renderer prefers it over `cmd.exe`; without it, it falls back to `cmd.exe`.
-- **(Windows Codex)** WSL with a normal Linux home under `/home/<user>`.
+- **Node.js 20+** with `npm`. Native Windows Node and WSL Node both work.
+- **(Windows, recommended)** `bash.exe` on your `PATH` — comes free with [Git for Windows](https://git-scm.com/download/win). The renderer prefers it over `cmd.exe`; without it, it falls back to `cmd.exe`.
 - **`gh`** — only if you will use `ralph-ghafk` (the GitHub-issue loop).
 
 ## 2. Install
@@ -21,7 +20,6 @@ npm i -g @daonhan/ralph
 ```
 
 Both bins — `ralph-afk` and `ralph-ghafk` — land on your `PATH`.
-On Windows, run this install inside WSL if you will use Codex.
 
 ## 3. Get the sandbox image
 
@@ -46,7 +44,7 @@ support is added.
 
 Credentials live on the **host** (`~/.claude` or `~/.codex`, plus `~/.config/gh`) and the selected provider's credentials get bind-mounted into each container. Log in once for the provider you will use. If you will run `ralph-ghafk`, authenticate GitHub separately after the provider login.
 
-**Same-shell rule:** credentials resolve against `$HOME` of the shell that launches the bin, and PowerShell `$HOME` (`C:\Users\<you>`) and WSL `$HOME` (`/home/<you>`) are separate stores — auth from the same shell context you will run the bins from. Native PowerShell and Git Bash homes are valid for Claude; Windows Codex requires WSL and a WSL Linux home.
+**Same-shell rule:** credentials resolve against `$HOME` of the shell that launches the bin, and PowerShell `$HOME` (`C:\Users\<you>`) and WSL `$HOME` (`/home/<you>`) are separate stores — auth from the same shell context you will run the bins from. Native PowerShell and Git Bash homes are valid for both providers.
 
 Choose one provider login path below. Claude and Codex authentication are
 mutually exclusive; GitHub authentication is provider-independent and required
@@ -87,10 +85,9 @@ exit
 
 ### Codex login
 
-Use this path instead when you select Codex. On Windows, native PowerShell, cmd,
-and Git Bash are not supported Codex launch contexts. Open WSL, then install the
-host CLI version pinned in Ralph's sandbox from the same WSL shell that will
-launch Ralph. On Linux and macOS, use the same native shell for both:
+Use this path instead when you select Codex. Install the host CLI version
+pinned in Ralph's sandbox from the same shell environment that will launch
+Ralph:
 
 ```bash
 npm install --global @openai/codex@0.144.4
@@ -111,14 +108,13 @@ codex login
 codex login status
 ```
 
-Ralph mounts `~/.codex` read-write at `/home/agent/.codex` so Codex can refresh
-the login. On Windows, keep `~/.codex` under `/home/<user>` in the WSL distro's
-Linux filesystem; the target workspace may still live under `/mnt/c` or
-`/mnt/d`. A native NTFS-backed mount fails when Codex performs required
-`chmod`/`fchmod` operations (`EPERM`). Switching only the command shell is not
-enough if the active Codex home still points at the Windows filesystem. Ralph
-runs Codex with `--ephemeral`, so stage session transcripts are not persisted
-there.
+Ralph mounts `~/.codex` read-only at `/mnt/codex-creds` and copies `auth.json`
+(plus `config.toml` and `AGENTS.md` when present) into a container-local
+`CODEX_HOME=/home/agent/.codex` before each stage, so native Windows homes work
+the same as Linux, macOS, and WSL ones. Codex never writes to the host
+credential store; a token refreshed inside the container is re-refreshed by the
+host CLI on its next use. Ralph runs Codex with `--ephemeral`, so stage session
+transcripts are not persisted either.
 
 Codex ignores the rest of `~/.codex/config.toml` by default. Use
 `--codex-user-config` only when you intentionally want its model settings, MCP
@@ -169,24 +165,25 @@ configuration read-only at `/home/agent/.config/gh` for the stage.
 Claude remains the default. Select Codex per invocation with `--agent codex`;
 `RALPH_AGENT=codex` is the fallback when that flag is absent.
 
-Linux / macOS / WSL bash (use WSL for Codex on Windows):
+Linux / macOS / WSL bash:
 
 ```bash
 ralph-afk "./docs/plans/x.md ./docs/prd/x.md" 5
 ralph-afk --agent codex "./docs/plans/x.md ./docs/prd/x.md" 5
 ```
 
-PowerShell (Claude only):
+PowerShell:
 
 ```powershell
 ralph-afk "./docs/plans/x.md ./docs/prd/x.md" 5
+ralph-afk --agent codex "./docs/plans/x.md ./docs/prd/x.md" 5
 ```
 
 ### GitHub-issue loop — `ralph-ghafk`
 
 No plan/PRD arg — context comes from open GitHub issues (`gh issue list`).
 
-Linux / macOS / WSL bash (use WSL for Codex on Windows):
+Linux / macOS / WSL bash:
 
 ```bash
 export GH_CONFIG_DIR="$HOME/.config/gh"
@@ -194,11 +191,12 @@ ralph-ghafk 5
 ralph-ghafk --agent codex 5
 ```
 
-PowerShell (Claude only):
+PowerShell:
 
 ```powershell
 $env:GH_CONFIG_DIR = "$HOME\.config\gh"
 ralph-ghafk 5
+ralph-ghafk --agent codex 5
 ```
 
 ## 6. How it ends / how to stop

--- a/README.md
+++ b/README.md
@@ -87,20 +87,20 @@ At runtime, the host workspace gets a `.ralph-tmp/` directory containing the per
 ## Prerequisites
 
 - **Docker** — Docker Desktop (Windows/macOS) or Docker Engine (Linux). The orchestrator shells out to `docker build` / `docker run`.
-- **Node.js 20+** + **npm 9+** (or `pnpm`/`yarn`). For Windows Claude runs: native nvm-for-windows, nvm-windows, or directly from nodejs.org. For Windows Codex runs: install Node inside WSL. For macOS/Linux: nvm, asdf, or a distro package.
+- **Node.js 20+** + **npm 9+** (or `pnpm`/`yarn`). For Windows: native nvm-for-windows, nvm-windows, directly from nodejs.org, or Node inside WSL. For macOS/Linux: nvm, asdf, or a distro package.
 - **`gh`** authenticated (only required for `ralph-ghafk`): `gh auth login` once.
 - **Claude Code or Codex** authentication for the provider you select. See "First-run setup" below.
-- **(Windows Claude only, optional but recommended)** `bash.exe` on PATH — comes free with [Git for Windows](https://git-scm.com/download/win). The renderer prefers it over `cmd.exe` because POSIX redirects + utilities (`git log`, `gh issue list`) are smoother. If absent, the renderer falls back to `cmd.exe` and uses the built-in try-shell tag (`!?\`cmd|||fallback\``) so commands that fail return their fallback string cleanly — no broken render.
+- **(Windows, optional but recommended)** `bash.exe` on PATH — comes free with [Git for Windows](https://git-scm.com/download/win). The renderer prefers it over `cmd.exe` because POSIX redirects + utilities (`git log`, `gh issue list`) are smoother. If absent, the renderer falls back to `cmd.exe` and uses the built-in try-shell tag (`!?\`cmd|||fallback\``) so commands that fail return their fallback string cleanly — no broken render.
 
 ### Supported shells / OS combinations
 
-| Where you invoke `ralph-afk` | Claude | Codex | Notes                                                                                           |
-| ---------------------------- | ------ | ----- | ----------------------------------------------------------------------------------------------- |
-| Linux native (Ubuntu, etc.)  | ✓      | ✓     | `/bin/bash` is used for shell tags.                                                             |
-| macOS native                 | ✓      | ✓     | `/bin/bash` is used.                                                                            |
-| Windows PowerShell / cmd     | ✓      | —     | Native Windows is supported for Claude. Codex requires WSL.                                     |
-| Windows + WSL bash           | ✓      | ✓     | Install Ralph, the selected host CLI, and credentials inside the same WSL distro.               |
-| Windows + Git Bash           | ✓      | —     | Native Git Bash and its Windows home are supported for Claude. Codex requires a WSL Linux home. |
+| Where you invoke `ralph-afk` | Claude | Codex | Notes                                                                             |
+| ---------------------------- | ------ | ----- | --------------------------------------------------------------------------------- |
+| Linux native (Ubuntu, etc.)  | ✓      | ✓     | `/bin/bash` is used for shell tags.                                               |
+| macOS native                 | ✓      | ✓     | `/bin/bash` is used.                                                              |
+| Windows PowerShell / cmd     | ✓      | ✓     | Native Windows is supported for both providers.                                   |
+| Windows + WSL bash           | ✓      | ✓     | Install Ralph, the selected host CLI, and credentials inside the same WSL distro. |
+| Windows + Git Bash           | ✓      | ✓     | Native Git Bash and its Windows home are supported for both providers.            |
 
 ### Windows + WSL: credentials
 
@@ -108,17 +108,16 @@ Credentials live on the **host** at `~/.claude` or `~/.codex` (for the selected 
 
 | Launch from              | `$HOME` is                        | Mounted into container                                              |
 | ------------------------ | --------------------------------- | ------------------------------------------------------------------- |
-| Windows PowerShell / cmd | `C:\Users\<name>`                 | Claude credentials under this home are mounted                      |
+| Windows PowerShell / cmd | `C:\Users\<name>`                 | The selected provider's credential store under this home is mounted |
 | WSL bash                 | `/home/<linuxname>`               | The selected provider's credential store under this home is mounted |
 | Linux / macOS            | `/home/<name>` or `/Users/<name>` | The selected provider's credential store under this home is mounted |
 
-**Windows Codex support requires WSL.** Install Ralph and the pinned host Codex
-CLI, run `codex login`, and invoke Ralph from the same WSL shell. Keep
-`~/.codex` in the WSL distro's Linux home (the ext4 filesystem), for example
-`/home/<linuxname>/.codex`. The target workspace may still live on Windows and
-be opened through `/mnt/c/...` or `/mnt/d/...`. A Windows-backed Codex home from
-PowerShell, cmd, or Git Bash is not supported; those native Windows homes remain
-valid for Claude.
+Codex works from native Windows shells and WSL alike: Ralph mounts `~/.codex`
+read-only at `/mnt/codex-creds` and copies `auth.json` (plus `config.toml` and
+`AGENTS.md` when present) into a container-local `CODEX_HOME` before each
+stage, so the credential home never sits on an NTFS-backed bind mount. Log in
+with the host Codex CLI (`codex login`) from the same shell environment that
+launches Ralph.
 
 If you already logged in via PowerShell `claude.exe` and want WSL to use those creds too:
 
@@ -152,8 +151,7 @@ Claude remains the default:
 ralph-afk "./docs/plans/x.md ./docs/prd/x.md" 5
 ```
 
-Select Codex per invocation. On Windows, run these commands from WSL as
-described above:
+Select Codex per invocation:
 
 ```bash
 ralph-afk --agent codex "./docs/plans/x.md ./docs/prd/x.md" 5
@@ -228,7 +226,7 @@ Required repo secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (a Docker Hub acc
 
 The image is stateless. Provider credentials live on the **host** at `~/.claude` or `~/.codex`. If you use `ralph-ghafk`, its provider-independent GitHub CLI credentials live at `~/.config/gh`. The orchestrator mounts only the selected provider's credentials, plus GitHub CLI credentials when present, into each container.
 
-> **Same-shell rule.** `ralph-afk` / `ralph-ghafk` read `$HOME` of the shell that launched them. Auth from the same shell context you intend to run the bins in. PowerShell host (`C:\Users\<you>\.config\gh\`) and WSL host (`\\wsl$\Ubuntu\home\<you>\.config\gh\`) are separate stores — don't mix. Native PowerShell and Git Bash homes are valid for Claude, but Windows Codex requires a WSL Linux home.
+> **Same-shell rule.** `ralph-afk` / `ralph-ghafk` read `$HOME` of the shell that launched them. Auth from the same shell context you intend to run the bins in. PowerShell host (`C:\Users\<you>\.config\gh\`) and WSL host (`\\wsl$\Ubuntu\home\<you>\.config\gh\`) are separate stores — don't mix. Native PowerShell and Git Bash homes are valid for both providers.
 
 Choose one provider login path below. Claude and Codex authentication are
 mutually exclusive; GitHub authentication is provider-independent and required
@@ -269,10 +267,9 @@ exit
 
 #### Codex login
 
-Use this path instead when you select Codex. On Windows, open WSL first; native
-PowerShell, cmd, and Git Bash are not supported Codex launch contexts. Install
-the host CLI version pinned in Ralph's sandbox from the same Linux, macOS, or
-WSL shell that will launch Ralph:
+Use this path instead when you select Codex. Install the host CLI version
+pinned in Ralph's sandbox from the same shell environment that will launch
+Ralph:
 
 ```bash
 npm install --global @openai/codex@0.144.4
@@ -293,11 +290,13 @@ codex login
 codex login status
 ```
 
-Ralph mounts `~/.codex` read-write at `/home/agent/.codex` so Codex can refresh
-the login. On Windows, that directory must be under the WSL Linux home, not on
-an NTFS mount; the workspace itself may remain under `/mnt/c` or `/mnt/d`.
-Ralph runs Codex with `--ephemeral`, so stage session transcripts are not
-persisted there.
+Ralph mounts `~/.codex` read-only at `/mnt/codex-creds` and copies `auth.json`
+(plus `config.toml` and `AGENTS.md` when present) into a container-local
+`CODEX_HOME=/home/agent/.codex` before each stage. Codex therefore never writes
+to the host credential store: an OAuth token refreshed inside the container is
+not written back, and the host CLI re-refreshes on its next use. Ralph runs
+Codex with `--ephemeral`, so stage session transcripts are not persisted
+either.
 
 #### GitHub login (`ralph-ghafk` only)
 
@@ -354,7 +353,7 @@ PowerShell:
 Get-ChildItem "$HOME\.claude\.credentials.json","$HOME\.claude.json"
 ```
 
-##### Codex credentials (Linux / macOS / WSL)
+##### Codex credentials
 
 ```bash
 codex login status
@@ -621,7 +620,7 @@ Use the pack-then-install path above. It exposes `ralph-afk` / `ralph-ghafk` glo
    ```
 4. `pnpm -r build` and republish.
 
-Only the first stage is the gate (sentinel-checked). Subsequent stages always run after a non-sentinel gate result. Ralph runs the selected provider without interactive approval (`permissionMode: "bypassPermissions"` for Claude; `--dangerously-bypass-approvals-and-sandbox` for Codex). With the Docker socket disabled, persistent host-write exposure still includes the workspace mount and selected provider's read-write credential store; GitHub CLI config is read-only.
+Only the first stage is the gate (sentinel-checked). Subsequent stages always run after a non-sentinel gate result. Ralph runs the selected provider without interactive approval (`permissionMode: "bypassPermissions"` for Claude; `--dangerously-bypass-approvals-and-sandbox` for Codex). With the Docker socket disabled, persistent host-write exposure still includes the workspace mount and, for Claude, the read-write credential store (Codex credentials are mounted read-only); GitHub CLI config is read-only.
 
 ### Change the template syntax
 
@@ -659,8 +658,8 @@ The agent playbooks are self-contained: `packages/core/templates/prompt.md` (pla
 - **`Cannot find module '@daonhan/ralph-core'`** — `@daonhan/ralph` was installed but its dep didn't resolve. Re-run `npm install` (or `pnpm install`) in the workspace, or use `npx -y @daonhan/ralph` to let npx fetch a clean copy.
 - **`@esbuild/win32-x64 package is present but this platform needs @esbuild/linux-x64`** — `node_modules/` installed from the wrong OS. Delete `node_modules/` + lockfile and reinstall under WSL.
 - **`Not logged in · Please run /login`** — Claude credentials are missing inside the container. Run the interactive `docker run … claude /login` step from "First-run setup".
-- **Codex reports that login is missing** — ensure `cli_auth_credentials_store = "file"`, run `codex login` from the same Linux, macOS, or WSL shell as Ralph, and confirm `codex login status` succeeds. On Windows, both login and Ralph must run in WSL with `~/.codex` under the WSL Linux home.
-- **Codex fails with `chmod` / `fchmod` `EPERM` on Windows** — `~/.codex` is backed by NTFS. Authenticate and invoke Ralph from WSL with `~/.codex` under `/home/<user>`; the workspace may stay under `/mnt/c` or `/mnt/d`. Switching only the command shell is insufficient if the active Codex home still points to the Windows filesystem.
+- **Codex reports that login is missing** — ensure `cli_auth_credentials_store = "file"`, run `codex login` from the same shell environment as Ralph (per the same-shell rule), and confirm `codex login status` succeeds and `~/.codex/auth.json` exists in that environment's home.
+- **Codex fails with `Operation not permitted (os error 1)` / `EPERM` at startup** — the container's `CODEX_HOME` is sitting on a Windows bind mount, which cannot host the unix socket and symlinks Codex creates at startup. Current Ralph avoids this by copying credentials into a container-local `CODEX_HOME`; upgrade `@daonhan/ralph` if you see this.
 - **Codex config, MCP servers, or hooks are missing** — isolated Codex intentionally ignores `~/.codex/config.toml`; opt in with `--codex-user-config` and ensure configured commands and paths work inside Linux Docker.
 - **An explicit Codex model fails** — fix or remove `RALPH_MODEL`. Ralph does not silently fall back to `gpt-5.6-sol` or another model after an explicit model failure.
 - **`gh issue list` fails with `not a git repository`** — the workspace has no `.git`. The `ghafk.md` template uses `|| echo "[]"` fallback so the iteration still proceeds, but `gh` cannot detect the target repo. Initialize the repo, or push first.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,15 +37,18 @@ The trust boundary is:
   bind-mounts the host filesystem as root). This is on so Testcontainers inside the sandbox can
   spawn sibling containers. **Disable it with `RALPH_DOCKER_SOCK=0`** when running anything you
   do not fully trust. Disabling it removes host-Docker control, but persistent host-write
-  exposure still includes the bind-mounted workspace and the selected provider's read-write
+  exposure still includes the bind-mounted workspace and, for Claude, the read-write
   credential store. `~/.config/gh` remains read-only.
 
-- **Selected-provider host credentials are bind-mounted read-write.** Claude
-  mounts `~/.claude` and `~/.claude.json`; Codex mounts `~/.codex`. The agent
-  can read or overwrite the selected provider's reusable credentials.
+- **Selected-provider host credentials are bind-mounted.** Claude mounts
+  `~/.claude` and `~/.claude.json` read-write; the agent can read or overwrite
+  those reusable credentials. Codex mounts `~/.codex` read-only at
+  `/mnt/codex-creds` and copies `auth.json` (plus `config.toml` and `AGENTS.md`
+  when present) into a container-local `CODEX_HOME`; the agent cannot modify
+  the host Codex store, but `auth.json` remains a readable reusable secret.
   `~/.config/gh` is mounted read-only. Isolated Codex configuration prevents
   personal config, MCP, and hook loading; it does not conceal
-  `~/.codex/auth.json`, which is a reusable secret, from the process.
+  `~/.codex/auth.json` from the process.
 
 ### Reducing blast radius
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -37,9 +37,8 @@ Claude is the default; `RALPH_AGENT=codex` is the fallback when `--agent` is abs
 Docker and a login for the selected provider (and `gh` for `ralph-ghafk`). Codex users should
 follow the root README's [file-backed login](https://github.com/daonhan/ralph#codex-login) and
 [provider configuration](https://github.com/daonhan/ralph#choose-the-coding-agent) instructions.
-On Windows, Codex requires Ralph, the pinned host Codex CLI, and `codex login` to run from WSL
-with `~/.codex` in the WSL Linux home; workspaces under `/mnt/c` or `/mnt/d` are supported.
-Native PowerShell, cmd, and Git Bash remain supported for Claude.
+Both providers run from native Windows shells (PowerShell, cmd, Git Bash) or WSL; log in with
+the host CLI from the same shell environment that launches Ralph.
 First-run setup, per-OS notes, and the full flag/env reference are in the
 **[main README](https://github.com/daonhan/ralph#readme)** and
 **[QUICKSTART](https://github.com/daonhan/ralph/blob/main/QUICKSTART.md)**.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -287,18 +287,17 @@ owns validation and a failure is terminal for that stage attempt—Ralph never r
 another model. `--codex-user-config` removes `--ignore-user-config`; when `RALPH_MODEL` is
 also unset, both model and reasoning effort come from `~/.codex/config.toml`.
 
-- **Workspace mount + `-w`:** the host workspace is mounted read-write and set as the container's working directory. The selected provider's credential store is a separate writable host mount.
+- **Workspace mount + `-w`:** the host workspace is mounted read-write and set as the container's working directory.
 - **Git env injection:** `GIT_CONFIG_COUNT/KEY_0/VALUE_0` forces `safe.directory=*` so git works against a bind-mount whose UID differs from the container user (a Windows-host pain point).
-- **Credential mounts** (only if the host path exists, resolved against `HOME || USERPROFILE`) are selected-provider-only: Claude mounts `~/.claude` and `~/.claude.json` (**rw**); Codex mounts only `~/.codex` (**rw**) and injects `CODEX_HOME=/home/agent/.codex`. Codex's `~/.codex/auth.json` is a reusable secret available to the process. Both may mount `~/.config/gh` (**ro**).
+- **Credential mounts** (only if the host path exists, resolved against `HOME || USERPROFILE`) are selected-provider-only: Claude mounts `~/.claude` and `~/.claude.json` (**rw**); Codex mounts `~/.codex` (**ro**) at `/mnt/codex-creds` and injects `CODEX_HOME=/home/agent/.codex` — a setup script wrapped around the `codex` invocation copies `auth.json`, `config.toml`, and `AGENTS.md` (when present) into the container-local `CODEX_HOME` before exec, because a bind-mounted `CODEX_HOME` cannot host the unix socket / symlinks Codex creates at startup (EPERM on Docker Desktop for Windows). Codex's `auth.json` is a reusable secret available to the process. Both may mount `~/.config/gh` (**ro**).
 - **Approval bypass** is provider-specific: Claude receives stage `permissionMode=bypassPermissions`; Codex receives `--dangerously-bypass-approvals-and-sandbox`.
 
 On Windows, the generic `HOME || USERPROFILE` resolution is a supported native
-launch path for Claude only. Codex requires Ralph, the pinned host Codex CLI,
-and `codex login` to run from the same WSL shell, with `~/.codex` in the WSL
-Linux home. A Windows/NTFS-backed Codex home cannot satisfy Codex's required
-`chmod`/`fchmod` calls and fails with `EPERM`; changing only the command shell
-does not relocate the credential home. The workspace may still be mounted from
-`/mnt/c` or `/mnt/d`. For `ralph-ghafk`, the same WSL shell must export
+launch path for both providers: the Codex credential home never sits on the
+NTFS bind mount (credentials are copied into the container-local `CODEX_HOME`
+instead), so the historical `chmod`/`fchmod`/unix-socket `EPERM` failures do
+not apply. Follow the same-shell rule — log in with the host CLI from the same
+environment that launches Ralph. For `ralph-ghafk` under WSL, export
 `GH_CONFIG_DIR="$HOME/.config/gh"` so the provider-independent GitHub config is
 the one mounted read-only.
 
@@ -363,7 +362,7 @@ Everything lands under `<workspace>/.ralph-tmp/` (gitignored):
 - **ESM only.** Both packages are `"type": "module"`; relative imports in `packages/core/src` end in `.js` (NodeNext).
 - **First stage is the gate.** Place gating stages at index 0 of any chain. The sentinel `<promise>NO MORE TASKS</promise>` is hardcoded in [`../packages/core/src/loop.ts`](../packages/core/src/loop.ts).
 - **No build step for `apps/cli`.** Bins are hand-written JS that `import { runAfk } from "@daonhan/ralph-core"`. Keep the bin layer flat — don't add TS there.
-- **`permissionMode` is always `bypassPermissions`** for sandbox stages — never `acceptEdits`. This supplies Claude's no-approval mode; Codex receives its provider-specific no-approval flag. With the Docker socket disabled, persistent host writes still include the workspace and selected provider's read-write credential store; GitHub CLI config is read-only.
+- **`permissionMode` is always `bypassPermissions`** for sandbox stages — never `acceptEdits`. This supplies Claude's no-approval mode; Codex receives its provider-specific no-approval flag. With the Docker socket disabled, persistent host writes still include the workspace and, for Claude, the read-write credential store (Codex credentials are mounted read-only); GitHub CLI config is read-only.
 - **Templates ship in the core tarball.** `packages/core/package.json` `files` includes `dist` and `templates` (the `Dockerfile` lives under `templates/`).
 - **Adding a stage** = (1) extend `STAGES` in [`../packages/core/src/stages.ts`](../packages/core/src/stages.ts), (2) drop a new `*.md` in [`../packages/core/templates`](../packages/core/templates), (3) wire it into the chain in `main.ts` / `gh-main.ts`.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,9 +39,9 @@ await runAfk(["--agent", "codex", "<plan-and-prd>", "5"]);
 
 The CLI equivalent is `ralph-afk --agent codex "<plan-and-prd>" 5` (or
 `ralph-ghafk --agent codex 5`). `RALPH_AGENT=codex` provides an environment fallback.
-On Windows, Codex is supported only when Ralph, the pinned host Codex CLI, and
-`codex login` all run from WSL with `~/.codex` in the WSL Linux home; the target
-workspace may remain under `/mnt/c` or `/mnt/d`. Native Windows remains supported for Claude.
+Both providers run from native Windows shells or WSL; log in with the host CLI
+from the same shell environment that launches Ralph (Codex needs file-backed
+credentials).
 See the root README's [Codex login](https://github.com/daonhan/ralph#codex-login) and
 [provider selection](https://github.com/daonhan/ralph#choose-the-coding-agent) sections,
 including isolated configuration, `--codex-user-config`, and model precedence.

--- a/packages/core/src/__tests__/agents.test.ts
+++ b/packages/core/src/__tests__/agents.test.ts
@@ -124,6 +124,17 @@ describe("Codex adapter", () => {
     });
   });
 
+  // CODEX_HOME lives inside the container; the setup script copies credentials
+  // from the read-only staging mount before exec'ing codex ($0="codex",
+  // $@=rest). A bind-mounted CODEX_HOME breaks on Docker Desktop for Windows
+  // (EPERM on the unix socket / symlinks Codex creates at startup).
+  const setupScript =
+    'mkdir -p "$CODEX_HOME"; ' +
+    "for f in auth.json config.toml AGENTS.md; do " +
+    'if [ -f "/mnt/codex-creds/$f" ]; then cp "/mnt/codex-creds/$f" "$CODEX_HOME/"; fi; ' +
+    "done; " +
+    'exec "$0" "$@"';
+
   it("builds isolated default args", () => {
     expect(
       buildCodexArgs({
@@ -133,6 +144,9 @@ describe("Codex adapter", () => {
         codexUserConfig: false,
       })
     ).toEqual([
+      "bash",
+      "-c",
+      setupScript,
       "codex",
       "exec",
       "--json",
@@ -156,6 +170,9 @@ describe("Codex adapter", () => {
         codexUserConfig: true,
       })
     ).toEqual([
+      "bash",
+      "-c",
+      setupScript,
       "codex",
       "exec",
       "--json",
@@ -174,6 +191,9 @@ describe("Codex adapter", () => {
         codexUserConfig: false,
       })
     ).toEqual([
+      "bash",
+      "-c",
+      setupScript,
       "codex",
       "exec",
       "--json",
@@ -191,7 +211,8 @@ describe("Codex adapter", () => {
     expect(adapter.credentialMounts("/home/me")).toEqual([
       {
         hostPath: "/home/me/.codex",
-        containerPath: "/home/agent/.codex",
+        containerPath: "/mnt/codex-creds",
+        readOnly: true,
       },
     ]);
     expect(adapter.containerEnv).toEqual({

--- a/packages/core/src/__tests__/runner.test.ts
+++ b/packages/core/src/__tests__/runner.test.ts
@@ -147,7 +147,8 @@ describe("resolveAgentRuntimeArgs", () => {
       expect(claudeArgs.join(" ")).not.toContain(".codex");
 
       const codexArgs = resolveAgentRuntimeArgs(getAgentAdapter("codex"), home);
-      expect(codexArgs.join(" ")).toContain("/home/agent/.codex");
+      expect(codexArgs.join(" ")).toContain("/mnt/codex-creds:ro");
+      expect(codexArgs.join(" ")).not.toContain(":/home/agent/.codex");
       expect(codexArgs.join(" ")).not.toContain(".claude");
       expect(codexArgs).toContain("CODEX_HOME=/home/agent/.codex");
       expect(codexArgs.join(" ")).toContain("/home/agent/.config/gh:ro");

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -255,8 +255,28 @@ export function resolveCodexModel(
   };
 }
 
+// CODEX_HOME must stay off the credential bind mount: Codex creates a unix
+// socket and symlinks in its home at startup, which Docker Desktop for
+// Windows bind mounts reject with "Operation not permitted (os error 1)"
+// (fatal at app-server init). The host ~/.codex is instead mounted read-only
+// at this staging path and the setup script copies the credential files into
+// a container-local CODEX_HOME before exec'ing codex ($0="codex", $@=rest).
+// Trade-off: an OAuth token refresh inside the container is not written back
+// to the host; the host CLI re-refreshes on its next use.
+const CODEX_CREDS_MOUNT = "/mnt/codex-creds";
+
+const CODEX_SETUP_SCRIPT =
+  'mkdir -p "$CODEX_HOME"; ' +
+  "for f in auth.json config.toml AGENTS.md; do " +
+  `if [ -f "${CODEX_CREDS_MOUNT}/$f" ]; then cp "${CODEX_CREDS_MOUNT}/$f" "$CODEX_HOME/"; fi; ` +
+  "done; " +
+  'exec "$0" "$@"';
+
 export function buildCodexArgs(context: AgentCommandContext): string[] {
   const args = [
+    "bash",
+    "-c",
+    CODEX_SETUP_SCRIPT,
     "codex",
     "exec",
     "--json",
@@ -290,7 +310,8 @@ export const codexAdapter = {
     return [
       {
         hostPath: joinHome(home, ".codex"),
-        containerPath: "/home/agent/.codex",
+        containerPath: CODEX_CREDS_MOUNT,
+        readOnly: true,
       },
     ];
   },


### PR DESCRIPTION
## Summary
Fix Codex credential setup so `CODEX_HOME` stays on container-local storage instead of a Windows bind mount that can cause permission errors.

## Why
On Windows, bind-mounting Codex home/config directly can fail with `EPERM` and break Codex startup in the sandbox. This change keeps credentials copied into local container storage and avoids mounting `CODEX_HOME` directly.

## What changed
- Updated Codex agent command/environment handling in `packages/core/src/agents/codex.ts`
- Added/updated tests for Codex and runner behavior
- Refreshed docs to describe current credential and runtime behavior

## Changed areas
- `packages/core/src/agents/codex.ts`
- `packages/core/src/__tests__/agents.test.ts`
- `packages/core/src/__tests__/runner.test.ts`
- `packages/core/README.md`
- `docs/ARCHITECTURE.md`
- `README.md` and other related docs