### PR TITLE
deps(cli): pick up @daonhan/ralph-core 0.8.0 (iteration history)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -30,8 +30,12 @@ ralph-ghafk 5                     # GitHub-issue loop
 ralph-afk --agent codex "<plan-and-prd>" 5
 ralph-ghafk --agent codex 5
 ralph-afk --help                  # flags, env vars
-ralph-afk --print-config          # diagnose workspace / docker context / image / socket
+ralph-afk --print-config          # diagnose workspace / docker context / image / socket / history dir
 ```
+
+Every run appends a readable history file under `<workspace>/.ralph/history/` (one Markdown file
+per run, self-gitignored) and injects the last ten stage entries into the next implementer prompt.
+Needs `@daonhan/ralph-core` 0.8.0 or later.
 
 Claude is the default; `RALPH_AGENT=codex` is the fallback when `--agent` is absent. Requires
 Docker and a login for the selected provider (and `gh` for `ralph-ghafk`). Codex users should


### PR DESCRIPTION
## What & why

The published CLI pins `@daonhan/ralph-core` at publish time (`^0.7.3` on 0.6.6), so users only get the iteration-history feature after a CLI release. release-please's open CLI PR #108 conflicts with the core 0.8.0 merge and, with no CLI commits since 0.6.6, release-please no longer rewrites it. This `deps(cli):` commit gives release-please a CLI change to build 0.6.7 from current main (it rewrites #108's branch), and documents `.ralph/history/` in the CLI README.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / clean-up (no behavior change)
- [x] Docs
- [x] CI / build / release

## Verification

- [x] `pnpm -r build`
- [x] `pnpm -r typecheck`
- [x] `pnpm -r test`
- [x] `pnpm test` (root `node --test`)
- [ ] Smoke scripts where relevant — README-only change

## Notes for reviewers

No code change; `apps/cli/README.md` only.