### PR TITLE
fix(ci): pass --repo to gh workflow run in the release dispatch step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,6 +110,7 @@ jobs:
           IMAGE_TAG="${TAG#ralph-sandbox-}"
           echo "Dispatching publish-image.yml for ${TAG} (${IMAGE_TAG})"
           gh workflow run publish-image.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref "$TAG" \
             -f tag="$IMAGE_TAG" \
             -f also_latest=true \


### PR DESCRIPTION
Fixes the release-please failure in run 34232539515: the "Publish released sandbox image" step ran in a job without a checkout (checkout is gated on `prs_created == 'true'`, but this run only had `releases_created == 'true'`), so `gh workflow run` failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`gh` needs `--repo` when no git repo is on disk. Passing `$GITHUB_REPOSITORY` makes the step independent of the checkout.

The v0.6.0 image itself was still published by the `ralph-sandbox-v*` tag-push trigger of publish-image.yml, so no release is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)